### PR TITLE
chore: pin rubash loop performance fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,7 +623,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 [[package]]
 name = "rubash"
 version = "0.2.0"
-source = "git+https://github.com/unixwin/rubash.git?rev=df626e2905ce1337849db6aff5405f14db168a9e#df626e2905ce1337849db6aff5405f14db168a9e"
+source = "git+https://github.com/unixwin/rubash.git?rev=8026e3bfa81f694646f13786242d8d8ebca79ab4#8026e3bfa81f694646f13786242d8d8ebca79ab4"
 dependencies = [
  "ctrlc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/unixwin/winuxsh"
 
 [dependencies]
 winuxsh-runtime = { path = "crates/winuxsh-runtime" }
-rubash = { git = "https://github.com/unixwin/rubash.git", rev = "df626e2905ce1337849db6aff5405f14db168a9e" }
+rubash = { git = "https://github.com/unixwin/rubash.git", rev = "8026e3bfa81f694646f13786242d8d8ebca79ab4" }
 anyhow = "1.0"
 env_logger = "0.10"
 log = "0.4"

--- a/DOCS/performance-investigation.md
+++ b/DOCS/performance-investigation.md
@@ -45,9 +45,32 @@ Measure-Command { bash .tmp/perf-nested-loops.sh }
   expansion, and per-command environment synchronization.
 - Host-facing fixes in this batch avoid extra work on command startup: stdin
   inheritance and script positional parameters are simple executor state writes.
-- If release-mode timings remain far from bash, profile `Executor::execute_ast`,
-  `expand_embedded_parameters`, and arithmetic evaluation before changing
-  winuxsh host code.
+- `rubash` PR #10 moved repeated loop body/condition AST construction out of
+  per-iteration hot paths and was merged as
+  `8026e3bfa81f694646f13786242d8d8ebca79ab4`.
+
+## 2026-07-26 benchmark snapshot
+
+These timings use the 80x80 microbenchmarks in
+`C:\Users\caomengxuan\repo\tmp\rubash-perf` after pinning `winuxsh` to
+`rubash` `8026e3bfa81f694646f13786242d8d8ebca79ab4`.
+
+| Script | Bash ms | winuxsh release ms | Median ratio |
+| --- | ---: | ---: | ---: |
+| `loop.sh` | 201.6, 160.3, 160.1 | 1329.0, 677.1, 653.3 | 4.2x |
+| `arith.sh` | 179.1, 172.7, 188.9 | 819.8, 854.3, 823.8 | 4.6x |
+| `function-noop.sh` | 206.2, 203.8, 211.0 | 1118.5, 1083.1, 1123.2 | 5.4x |
+| `function-args-arith.sh` | 279.4, 303.4, 303.4 | 1656.5, 1603.5, 1632.7 | 5.4x |
+
+Direct `rubash` benchmarking before the `winuxsh` dependency bump showed the
+loop-only case improving from roughly 635-996 ms to 532-536 ms, and the
+function-plus-args-plus-arithmetic case improving from roughly 1655-1710 ms to
+1498-1550 ms. That confirms the merged `rubash` optimization helps, but the
+remaining gap is still large enough to keep issue #18 open for more profiling.
+
+Next profiling targets should be `Executor::execute_ast`,
+`expand_embedded_parameters`, shell function dispatch, and arithmetic evaluation
+before changing `winuxsh` host code.
 
 ## Follow-up
 

--- a/crates/winuxsh-runtime/Cargo.toml
+++ b/crates/winuxsh-runtime/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0-or-later"
 description = "Runtime crate for winuxsh: rubash-backed shell REPL on Windows"
 
 [dependencies]
-rubash = { git = "https://github.com/unixwin/rubash.git", rev = "df626e2905ce1337849db6aff5405f14db168a9e" }
+rubash = { git = "https://github.com/unixwin/rubash.git", rev = "8026e3bfa81f694646f13786242d8d8ebca79ab4" }
 reedline = "0.33"
 anyhow = "1.0"
 thiserror = "1.0"


### PR DESCRIPTION
## Summary
- Pin `rubash` to `8026e3bfa81f694646f13786242d8d8ebca79ab4`, which includes unixwin/rubash#10 loop AST reuse.
- Update the performance investigation note for issue #18 with fresh 80x80 microbenchmark results.
- Keep issue #18 open as a profiling follow-up because release `winuxsh` remains about 4-5x slower than Git Bash on the function-heavy workload.

## Benchmark snapshot
Post-upgrade release timings, 3 runs each:

- `loop.sh`: bash 201.6, 160.3, 160.1 ms; winuxsh 1329.0, 677.1, 653.3 ms
- `arith.sh`: bash 179.1, 172.7, 188.9 ms; winuxsh 819.8, 854.3, 823.8 ms
- `function-noop.sh`: bash 206.2, 203.8, 211.0 ms; winuxsh 1118.5, 1083.1, 1123.2 ms
- `function-args-arith.sh`: bash 279.4, 303.4, 303.4 ms; winuxsh 1656.5, 1603.5, 1632.7 ms

## Tests
- `cargo check --locked`
- `cargo test --locked`
- `cargo build --release --locked`