### PR TITLE
chore: pin rubash command bookkeeping perf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -358,7 +358,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -465,7 +465,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -623,7 +623,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 [[package]]
 name = "rubash"
 version = "0.2.0"
-source = "git+https://github.com/unixwin/rubash.git?rev=8026e3bfa81f694646f13786242d8d8ebca79ab4#8026e3bfa81f694646f13786242d8d8ebca79ab4"
+source = "git+https://github.com/unixwin/rubash.git?rev=8caab03257d9902f2d5215fe9b72f05052b204a4#8caab03257d9902f2d5215fe9b72f05052b204a4"
 dependencies = [
  "ctrlc",
  "libc",
@@ -641,7 +641,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/unixwin/winuxsh"
 
 [dependencies]
 winuxsh-runtime = { path = "crates/winuxsh-runtime" }
-rubash = { git = "https://github.com/unixwin/rubash.git", rev = "8026e3bfa81f694646f13786242d8d8ebca79ab4" }
+rubash = { git = "https://github.com/unixwin/rubash.git", rev = "8caab03257d9902f2d5215fe9b72f05052b204a4" }
 anyhow = "1.0"
 env_logger = "0.10"
 log = "0.4"

--- a/DOCS/performance-investigation.md
+++ b/DOCS/performance-investigation.md
@@ -48,6 +48,13 @@ Measure-Command { bash .tmp/perf-nested-loops.sh }
 - `rubash` PR #10 moved repeated loop body/condition AST construction out of
   per-iteration hot paths and was merged as
   `8026e3bfa81f694646f13786242d8d8ebca79ab4`.
+- `rubash` PR #11 targeted the larger remaining hot path: per-command
+  bookkeeping in `Executor::execute_command`. Windows WPR and `samply` were
+  blocked locally, so temporary internal timing was used and removed before the
+  PR. The patch avoids unconditional `BASH_COMMAND` text construction,
+  avoids process-env sync for function call state, conditionally syncs
+  diagnostic line numbers, and reuses function body ASTs across calls. It was
+  merged as `8caab03257d9902f2d5215fe9b72f05052b204a4`.
 
 ## 2026-07-26 benchmark snapshot
 
@@ -68,9 +75,35 @@ function-plus-args-plus-arithmetic case improving from roughly 1655-1710 ms to
 1498-1550 ms. That confirms the merged `rubash` optimization helps, but the
 remaining gap is still large enough to keep issue #18 open for more profiling.
 
-Next profiling targets should be `Executor::execute_ast`,
-`expand_embedded_parameters`, shell function dispatch, and arithmetic evaluation
-before changing `winuxsh` host code.
+## 2026-07-26 command bookkeeping follow-up
+
+After `rubash` PR #11, direct `rubash` release medians improved materially on
+the same 80x80 scripts:
+
+| Script | rubash baseline ms | rubash patched ms | Change |
+| --- | ---: | ---: | ---: |
+| `loop.sh` | 448.28 | 330.83 | -26.2% |
+| `arith.sh` | 519.30 | 428.06 | -17.6% |
+| `function-noop.sh` | 732.08 | 545.44 | -25.5% |
+| `function-args-arith.sh` | 1126.39 | 827.02 | -26.6% |
+
+After pinning `winuxsh` to
+`rubash` `8caab03257d9902f2d5215fe9b72f05052b204a4`, release medians are:
+
+| Script | Bash ms | winuxsh release ms | Median ratio |
+| --- | ---: | ---: | ---: |
+| `loop.sh` | 167.84 | 560.63 | 3.3x |
+| `arith.sh` | 177.31 | 771.40 | 4.4x |
+| `function-noop.sh` | 237.48 | 879.30 | 3.7x |
+| `function-args-arith.sh` | 276.67 | 1260.52 | 4.6x |
+
+Compared with the prior `winuxsh` snapshot, the new pin reduces median wall
+time by about 17% on loop-only, 6% on arithmetic-heavy, 21% on function-noop,
+and 23% on function-plus-args-plus-arithmetic. The remaining gap still appears
+rubash-executor dominated, so the next profiling targets should be
+`expand_embedded_parameters`, command/function dispatch overhead that remains
+after PR #11, arithmetic evaluation, and any Windows process/environment calls
+still reached from hot shell loops.
 
 ## Follow-up
 

--- a/crates/winuxsh-runtime/Cargo.lock
+++ b/crates/winuxsh-runtime/Cargo.lock
@@ -218,7 +218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -375,7 +375,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -482,7 +482,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -646,7 +646,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 [[package]]
 name = "rubash"
 version = "0.2.0"
-source = "git+https://github.com/unixwin/rubash.git?rev=df626e2905ce1337849db6aff5405f14db168a9e#df626e2905ce1337849db6aff5405f14db168a9e"
+source = "git+https://github.com/unixwin/rubash.git?rev=8caab03257d9902f2d5215fe9b72f05052b204a4#8caab03257d9902f2d5215fe9b72f05052b204a4"
 dependencies = [
  "ctrlc",
  "libc",
@@ -664,7 +664,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -840,7 +840,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/winuxsh-runtime/Cargo.toml
+++ b/crates/winuxsh-runtime/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0-or-later"
 description = "Runtime crate for winuxsh: rubash-backed shell REPL on Windows"
 
 [dependencies]
-rubash = { git = "https://github.com/unixwin/rubash.git", rev = "8026e3bfa81f694646f13786242d8d8ebca79ab4" }
+rubash = { git = "https://github.com/unixwin/rubash.git", rev = "8caab03257d9902f2d5215fe9b72f05052b204a4" }
 reedline = "0.33"
 anyhow = "1.0"
 thiserror = "1.0"


### PR DESCRIPTION
## Summary
- pin root and runtime crates to `rubash` `8caab03257d9902f2d5215fe9b72f05052b204a4`
- refresh both Cargo.lock files
- update `DOCS/performance-investigation.md` with the rubash PR #11 hotspot method and new release benchmark medians

## Benchmark notes
Release build, 7 runs each, median wall time on the local Windows machine:

| script | Git Bash | winuxsh release | ratio |
| --- | ---: | ---: | ---: |
| loop | 167.84 ms | 560.63 ms | 3.3x |
| arith | 177.31 ms | 771.40 ms | 4.4x |
| function-noop | 237.48 ms | 879.30 ms | 3.7x |
| function-args-arith | 276.67 ms | 1260.52 ms | 4.6x |

Compared with the prior winuxsh snapshot from the previous rubash pin, median wall time is down about 17% on loop-only, 6% on arithmetic-heavy, 21% on function-noop, and 23% on function-plus-args-plus-arithmetic.

## Tests
- `cargo check --locked`
- `cargo test --locked`
- `cargo build --release --locked`