### PR TITLE
feat: add opt-in winuxfetch startup hook

### DIFF
--- a/DOCS/getting-started.md
+++ b/DOCS/getting-started.md
@@ -133,7 +133,29 @@ matching = "prefix"
 # coreutils directory already on PATH.
 ```
 
-## 6b. Segment-based prompt (experimental)
+## 6b. Optional startup banner
+
+`winuxfetch` prints a compact Neofetch-style Windows system card. It is a
+separate executable, so normal shell startup stays quiet unless you opt in.
+
+Run it manually:
+
+```bash
+winuxfetch
+winuxfetch --no-logo
+```
+
+Show it once when the interactive REPL starts:
+
+```toml
+[hooks]
+startup = ["winuxfetch"]
+```
+
+`startup` hooks run only in the interactive REPL. They do not run for
+`winuxsh -c ...`, script files, or stdin script execution.
+
+## 6c. Segment-based prompt (experimental)
 
 Enable the p10k-style segment engine by adding to `~/.winshrc.toml`:
 

--- a/DOCS/zsh-compatibility-plan.md
+++ b/DOCS/zsh-compatibility-plan.md
@@ -638,6 +638,7 @@ plugins actionable without executing zsh plugin scripts:
 
 ```toml
 [hooks]
+startup = ["winuxfetch"]
 precmd = ["echo before prompt"]
 preexec = ["echo before command"]
 chpwd = ["echo directory changed"]
@@ -645,6 +646,7 @@ chpwd = ["echo directory changed"]
 
 Current behavior:
 
+- `startup` hooks run once after REPL startup setup and before the first prompt.
 - `precmd` hooks run before each interactive prompt render.
 - `preexec` hooks run before each non-empty interactive command.
 - `chpwd` hooks run after an interactive command changes the current directory.
@@ -655,8 +657,8 @@ Current behavior:
   does not source `precmd()`, `preexec()`, `chpwd()`, or `add-zsh-hook` bodies
   from zsh plugins.
 - Hook context is exposed through temporary shell variables:
-  `WINUXSH_LAST_EXIT_CODE`, `WINUXSH_PREEXEC_COMMAND`, `WINUXSH_OLDPWD`, and
-  `WINUXSH_PWD`.
+  `WINUXSH_REPL_STARTUP`, `WINUXSH_LAST_EXIT_CODE`,
+  `WINUXSH_PREEXEC_COMMAND`, `WINUXSH_OLDPWD`, and `WINUXSH_PWD`.
 - The hook path is REPL-only. `winuxsh -c ...` and script-file execution remain
   deterministic and do not run interactive lifecycle hooks.
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -206,6 +206,11 @@ completion_page_size = 10
 history_page_size = 10
 max_entry_lines = 5
 
+[hooks]
+# 可选：REPL 启动时只显示一次 Neofetch 风格系统信息。
+# 不会在 `winuxsh -c` 或脚本文件执行时运行。
+# startup = ["winuxfetch"]
+
 [winuxcmd]
 # 可选覆盖；省略时从 PATH 自动发现。
 # path = "D:/tools/winuxcmd/winuxcmd.exe"

--- a/README.md
+++ b/README.md
@@ -202,6 +202,11 @@ ll = "ls -la"
 [completions]
 matching = "prefix"           # prefix | substring
 case_sensitive = false
+
+[hooks]
+# Optional: show a Neofetch-style system card once when the REPL starts.
+# This never runs for `winuxsh -c` or script files.
+# startup = ["winuxfetch"]
 ```
 
 Full reference with all options: [DOCS/getting-started.md](DOCS/getting-started.md).
@@ -227,7 +232,7 @@ Full reference with all options: [DOCS/getting-started.md](DOCS/getting-started.
 - Report a bug?  Open an issue.
 - Want a feature?  Check [the roadmap](DOCS/winuxsh-roadmap.md).
 - Build from source: `cargo build --release`.
-- Release zip includes `winuxsh.exe`, `winuxcmd/winuxcmd.exe`, and `winuxcmd/activate-winuxcmd.sh`.
+- Release zip includes `winuxsh.exe`, `winuxfetch.exe`, `winuxcmd/winuxcmd.exe`, and `winuxcmd/activate-winuxcmd.sh`.
 - On first start, winuxsh runs the activation script once if command links are missing.
 - Run the tests: `cargo test`.
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,29 @@
+# Third-Party Notices
+
+## Neofetch
+
+`winuxfetch` includes Windows ASCII art adapted from Neofetch.
+
+Project: https://github.com/dylanaraps/neofetch
+
+The MIT License (MIT)
+
+Copyright (c) 2015-2021 Dylan Araps
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/winuxsh-runtime/src/config.rs
+++ b/crates/winuxsh-runtime/src/config.rs
@@ -10,19 +10,19 @@ use crate::prompt::PromptIndicators;
 
 /// Shell configuration, loaded from `~/.winshrc.toml`.
 #[derive(Debug, Clone, Default)]
- pub struct ShellConfig {
-     /// Prompt indicator symbol (e.g. "%", "\$", "\u276f", "\u3bb")
-     pub prompt_symbol: String,
-     /// Prompt template (e.g. "{user}@{host} {cwd} {symbol}")
-     pub prompt_format: Option<String>,
- /// Optional right-side prompt template.
- pub right_prompt_format: Option<String>,
- /// Optional format for the git prompt segment. Supports `{git_branch}` and
- /// `{git_status}` placeholders, e.g. `git:({git_branch})`. When unset, the
- /// branch name is rendered on its own.
- pub git_prompt_format: Option<String>,
- /// Optional mode-specific prompt indicators.
- pub prompt_indicators: PromptIndicators,
+pub struct ShellConfig {
+    /// Prompt indicator symbol (e.g. "%", "\$", "\u276f", "\u3bb")
+    pub prompt_symbol: String,
+    /// Prompt template (e.g. "{user}@{host} {cwd} {symbol}")
+    pub prompt_format: Option<String>,
+    /// Optional right-side prompt template.
+    pub right_prompt_format: Option<String>,
+    /// Optional format for the git prompt segment. Supports `{git_branch}` and
+    /// `{git_status}` placeholders, e.g. `git:({git_branch})`. When unset, the
+    /// branch name is rendered on its own.
+    pub git_prompt_format: Option<String>,
+    /// Optional mode-specific prompt indicators.
+    pub prompt_indicators: PromptIndicators,
     /// Prompt backend: "template" (legacy) or "segments" (p10k-style).
     pub prompt_style: Option<String>,
     /// Segment preset: "lean" | "classic" | "rainbow" | "pure" | "robbyrussell".
@@ -31,10 +31,11 @@ use crate::prompt::PromptIndicators;
     pub left_prompt_elements: Option<Vec<String>>,
     /// Custom right-prompt segment order (overrides preset).
     pub right_prompt_elements: Option<Vec<String>>,
- }
+}
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct HookConfig {
+    pub startup: Vec<String>,
     pub precmd: Vec<String>,
     pub preexec: Vec<String>,
     pub chpwd: Vec<String>,
@@ -459,6 +460,7 @@ struct WinuxCmdToml {
 
 #[derive(Debug, Deserialize)]
 struct HooksToml {
+    startup: Option<Vec<String>>,
     precmd: Option<Vec<String>>,
     preexec: Option<Vec<String>>,
     chpwd: Option<Vec<String>>,
@@ -844,8 +846,10 @@ fn build_prompt_indicators(parsed: &ShellToml) -> PromptIndicators {
             .unwrap_or(defaults.history_search_fail),
     }
 }
+
 fn build_hook_config(parsed: HooksToml) -> HookConfig {
     HookConfig {
+        startup: parsed.startup.unwrap_or_default(),
         precmd: parsed.precmd.unwrap_or_default(),
         preexec: parsed.preexec.unwrap_or_default(),
         chpwd: parsed.chpwd.unwrap_or_default(),
@@ -1179,12 +1183,14 @@ edit_mode = "unknown"
         let config = parse_config(
             r#"
 [hooks]
+startup = ["winuxfetch"]
 precmd = ["echo before prompt"]
 preexec = ["echo before command"]
 chpwd = ["echo directory changed"]
 "#,
         );
 
+        assert_eq!(config.hooks.startup, vec!["winuxfetch"]);
         assert_eq!(config.hooks.precmd, vec!["echo before prompt"]);
         assert_eq!(config.hooks.preexec, vec!["echo before command"]);
         assert_eq!(config.hooks.chpwd, vec!["echo directory changed"]);

--- a/crates/winuxsh-runtime/src/repl.rs
+++ b/crates/winuxsh-runtime/src/repl.rs
@@ -679,6 +679,7 @@ pub fn run_repl(shell: &mut Shell) -> anyhow::Result<()> {
     println!();
 
     shell.restore_last_working_dir_for_repl();
+    shell.run_startup_hooks();
     let mut line_editor = build_line_editor(shell)?;
     let mut pending = PendingReplInput::default();
 

--- a/crates/winuxsh-runtime/src/shell.rs
+++ b/crates/winuxsh-runtime/src/shell.rs
@@ -469,15 +469,22 @@ impl Shell {
         self.update_completion_state();
     }
 
+    /// Run native hooks once after REPL startup, before the first prompt.
+    pub fn run_startup_hooks(&mut self) {
+        let hooks = self.hooks.startup.clone();
+        self.run_hook_scripts(&hooks, &[("WINUXSH_REPL_STARTUP", "1".to_string())]);
+        self.update_completion_state();
+    }
+
     /// Run native hooks before rendering the next prompt.
- pub fn run_precmd_hooks(&mut self) {
-     self.run_native_precmd_plugins();
-     let hooks = self.hooks.precmd.clone();
-     let last_exit_code = self.executor.last_exit_code().to_string();
-    // Set in process env so segment prompt can read it via std::env::var.
-    std::env::set_var("WINUXSH_LAST_EXIT_CODE", &last_exit_code);
-     self.run_hook_scripts(&hooks, &[("WINUXSH_LAST_EXIT_CODE", last_exit_code)]);
- }
+    pub fn run_precmd_hooks(&mut self) {
+        self.run_native_precmd_plugins();
+        let hooks = self.hooks.precmd.clone();
+        let last_exit_code = self.executor.last_exit_code().to_string();
+        // Set in process env so segment prompt can read it via std::env::var.
+        std::env::set_var("WINUXSH_LAST_EXIT_CODE", &last_exit_code);
+        self.run_hook_scripts(&hooks, &[("WINUXSH_LAST_EXIT_CODE", last_exit_code)]);
+    }
 
     /// Run native hooks immediately before the user's interactive command.
     pub fn run_preexec_hooks(&mut self, command: &str) {
@@ -1896,16 +1903,19 @@ mod tests {
         let next_arg = shell_quote(&shell_display_path(&next_dir));
 
         let mut shell = test_shell(HookConfig {
+            startup: vec!["HOOK_STARTUP=\"startup:$WINUXSH_REPL_STARTUP\"".to_string()],
             precmd: vec!["HOOK_PRECMD=\"precmd:$WINUXSH_LAST_EXIT_CODE\"".to_string()],
             preexec: vec!["HOOK_PREEXEC=\"preexec:$WINUXSH_PREEXEC_COMMAND\"".to_string()],
             chpwd: vec!["HOOK_CHPWD=\"chpwd:$WINUXSH_OLDPWD->$WINUXSH_PWD\"".to_string()],
         });
 
+        shell.run_startup_hooks();
         shell.run_precmd_hooks();
         shell
             .execute_interactive_line(&format!("cd {}", next_arg))
             .unwrap();
 
+        assert_eq!(shell.executor.get_env("HOOK_STARTUP"), Some("startup:1"));
         assert_eq!(shell.executor.get_env("HOOK_PRECMD"), Some("precmd:0"));
         let preexec = shell.executor.get_env("HOOK_PREEXEC").unwrap_or_default();
         assert!(preexec.starts_with("preexec:cd "), "{preexec}");
@@ -1913,6 +1923,7 @@ mod tests {
         assert!(chpwd.starts_with("chpwd:"), "{chpwd}");
         assert!(chpwd.contains("->"), "{chpwd}");
         assert!(shell.executor.get_env("WINUXSH_LAST_EXIT_CODE").is_none());
+        assert!(shell.executor.get_env("WINUXSH_REPL_STARTUP").is_none());
         assert!(shell.executor.get_env("WINUXSH_PREEXEC_COMMAND").is_none());
         assert!(shell.executor.get_env("WINUXSH_OLDPWD").is_none());
         assert!(shell.executor.get_env("WINUXSH_PWD").is_none());

--- a/scripts/package-release.ps1
+++ b/scripts/package-release.ps1
@@ -22,11 +22,13 @@ try {
 
     if ($Target) {
         $winuxshExe = Join-Path $RepoRoot "target\$Target\$Configuration\winuxsh.exe"
+        $winuxfetchExe = Join-Path $RepoRoot "target\$Target\$Configuration\winuxfetch.exe"
     }
     else {
         $winuxshExe = Join-Path $RepoRoot "target\$Configuration\winuxsh.exe"
+        $winuxfetchExe = Join-Path $RepoRoot "target\$Configuration\winuxfetch.exe"
     }
-    if (-not (Test-Path -LiteralPath $winuxshExe)) {
+    if (-not (Test-Path -LiteralPath $winuxshExe) -or -not (Test-Path -LiteralPath $winuxfetchExe)) {
         $buildArgs = @("build", "--locked")
         if ($Configuration -eq "release") {
             $buildArgs += "--release"
@@ -38,6 +40,9 @@ try {
     }
     if (-not (Test-Path -LiteralPath $winuxshExe)) {
         throw "winuxsh.exe not found at $winuxshExe"
+    }
+    if (-not (Test-Path -LiteralPath $winuxfetchExe)) {
+        throw "winuxfetch.exe not found at $winuxfetchExe"
     }
 
     if (-not $WinuxCmdPath -and $AllowPathWinuxCmd) {
@@ -53,6 +58,10 @@ try {
     $activationScript = Join-Path $RepoRoot "assets\winuxcmd\activate-winuxcmd.sh"
     if (-not (Test-Path -LiteralPath $activationScript)) {
         throw "Activation script not found at $activationScript"
+    }
+    $thirdPartyNotices = Join-Path $RepoRoot "THIRD_PARTY_NOTICES.md"
+    if (-not (Test-Path -LiteralPath $thirdPartyNotices)) {
+        throw "Third-party notices not found at $thirdPartyNotices"
     }
 
     $distDir = Join-Path $RepoRoot "dist"
@@ -70,8 +79,10 @@ try {
     New-Item -ItemType Directory -Force -Path (Join-Path $stageDir "winuxcmd") | Out-Null
 
     Copy-Item -LiteralPath $winuxshExe -Destination (Join-Path $stageDir "winuxsh.exe") -Force
+    Copy-Item -LiteralPath $winuxfetchExe -Destination (Join-Path $stageDir "winuxfetch.exe") -Force
     Copy-Item -LiteralPath $WinuxCmdPath -Destination (Join-Path $stageDir "winuxcmd\winuxcmd.exe") -Force
     Copy-Item -LiteralPath $activationScript -Destination (Join-Path $stageDir "winuxcmd\activate-winuxcmd.sh") -Force
+    Copy-Item -LiteralPath $thirdPartyNotices -Destination (Join-Path $stageDir "THIRD_PARTY_NOTICES.md") -Force
 
     Compress-Archive -LiteralPath $stageDir -DestinationPath $zipPath -Force
 

--- a/src/bin/winuxfetch.rs
+++ b/src/bin/winuxfetch.rs
@@ -1,0 +1,279 @@
+//! winuxfetch: small Neofetch-style system summary for Winuxsh users.
+//!
+//! The Windows ASCII logo is adapted from Neofetch.
+//! See THIRD_PARTY_NOTICES.md for the Neofetch MIT license notice.
+
+use std::collections::HashMap;
+use std::env;
+use std::process::Command;
+
+const RESET: &str = "\x1b[0m";
+const CYAN: &str = "\x1b[36;1m";
+const GREEN: &str = "\x1b[32;1m";
+const BOLD: &str = "\x1b[1m";
+
+const WINDOWS_LOGO: &[&str] = &[
+    "################  ################",
+    "################  ################",
+    "################  ################",
+    "################  ################",
+    "################  ################",
+    "################  ################",
+    "################  ################",
+    "",
+    "################  ################",
+    "################  ################",
+    "################  ################",
+    "################  ################",
+    "################  ################",
+    "################  ################",
+    "################  ################",
+];
+
+#[derive(Debug, Default)]
+struct FetchOptions {
+    no_logo: bool,
+    no_color: bool,
+    help: bool,
+    license: bool,
+}
+
+#[derive(Debug, Default)]
+struct SystemInfo {
+    os: Option<String>,
+    kernel: Option<String>,
+    host: Option<String>,
+    uptime: Option<String>,
+    cpu: Option<String>,
+    memory: Option<String>,
+}
+
+fn main() {
+    let options = parse_args(env::args().skip(1));
+
+    if options.help {
+        print_help();
+        return;
+    }
+    if options.license {
+        print_license_notice();
+        return;
+    }
+
+    let no_color = options.no_color || env::var_os("NO_COLOR").is_some();
+    let info = collect_system_info();
+    let lines = info_lines(&info, no_color);
+
+    if options.no_logo {
+        for line in lines {
+            println!("{line}");
+        }
+        return;
+    }
+
+    print_with_logo(&lines, no_color);
+}
+
+fn parse_args(args: impl Iterator<Item = String>) -> FetchOptions {
+    let mut options = FetchOptions::default();
+    for arg in args {
+        match arg.as_str() {
+            "-h" | "--help" => options.help = true,
+            "--license" => options.license = true,
+            "--no-logo" | "--off" => options.no_logo = true,
+            "--no-color" | "--plain" => options.no_color = true,
+            _ => {}
+        }
+    }
+    options
+}
+
+fn print_help() {
+    println!(
+        "winuxfetch {} - Neofetch-style system info for Winuxsh",
+        env!("CARGO_PKG_VERSION")
+    );
+    println!();
+    println!("Usage: winuxfetch [--no-logo] [--no-color] [--license]");
+    println!();
+    println!("Options:");
+    println!("  --no-logo, --off   Print info without ASCII art");
+    println!("  --no-color, --plain Disable ANSI colors");
+    println!("  --license          Show third-party attribution");
+    println!("  -h, --help         Show this help");
+}
+
+fn print_license_notice() {
+    println!("winuxfetch includes Windows ASCII art adapted from Neofetch.");
+    println!("Neofetch is MIT licensed:");
+    println!("Copyright (c) 2015-2021 Dylan Araps");
+    println!("See THIRD_PARTY_NOTICES.md in the Winuxsh source distribution.");
+}
+
+fn collect_system_info() -> SystemInfo {
+    let mut info = powershell_system_info().unwrap_or_default();
+
+    if info.os.is_none() {
+        info.os = Some(default_os_label());
+    }
+    if info.kernel.is_none() {
+        info.kernel = Some(env::consts::ARCH.to_string());
+    }
+    if info.host.is_none() {
+        info.host = env::var("COMPUTERNAME")
+            .ok()
+            .or_else(|| env::var("HOSTNAME").ok());
+    }
+    if info.cpu.is_none() {
+        info.cpu = Some(env::consts::ARCH.to_string());
+    }
+
+    info
+}
+
+fn powershell_system_info() -> Option<SystemInfo> {
+    if !cfg!(windows) {
+        return None;
+    }
+
+    let script = r#"
+$os = Get-CimInstance Win32_OperatingSystem
+$cpu = Get-CimInstance Win32_Processor | Select-Object -First 1
+$cs = Get-CimInstance Win32_ComputerSystem
+$uptime = (Get-Date) - $os.LastBootUpTime
+$total = [int64]$os.TotalVisibleMemorySize
+$free = [int64]$os.FreePhysicalMemory
+$used = $total - $free
+Write-Output ("OS=" + $os.Caption)
+Write-Output ("KERNEL=" + $os.Version)
+Write-Output ("HOST=" + (($cs.Manufacturer, $cs.Model | Where-Object { $_ }) -join " "))
+Write-Output ("UPTIME={0}d {1}h {2}m" -f [int]$uptime.TotalDays, $uptime.Hours, $uptime.Minutes)
+Write-Output ("CPU=" + $cpu.Name)
+Write-Output ("MEMORY={0} MiB / {1} MiB" -f [int]($used / 1024), [int]($total / 1024))
+"#;
+
+    let output = Command::new("powershell.exe")
+        .args([
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            script,
+        ])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let pairs = stdout
+        .lines()
+        .filter_map(|line| line.split_once('='))
+        .map(|(key, value)| (key.trim().to_ascii_uppercase(), value.trim().to_string()))
+        .filter(|(_, value)| !value.is_empty())
+        .collect::<HashMap<_, _>>();
+
+    Some(SystemInfo {
+        os: pairs.get("OS").cloned(),
+        kernel: pairs.get("KERNEL").cloned(),
+        host: pairs.get("HOST").cloned(),
+        uptime: pairs.get("UPTIME").cloned(),
+        cpu: pairs.get("CPU").cloned(),
+        memory: pairs.get("MEMORY").cloned(),
+    })
+}
+
+fn info_lines(info: &SystemInfo, no_color: bool) -> Vec<String> {
+    let title = format!(
+        "{}@{}",
+        env::var("USERNAME")
+            .or_else(|_| env::var("USER"))
+            .unwrap_or_else(|_| "user".to_string()),
+        env::var("COMPUTERNAME")
+            .or_else(|_| env::var("HOSTNAME"))
+            .unwrap_or_else(|_| "host".to_string())
+    );
+    let underline = "-".repeat(title.chars().count());
+    let shell = format!("winuxsh {}", env!("CARGO_PKG_VERSION"));
+    let terminal = terminal_name();
+
+    let mut lines = Vec::new();
+    lines.push(accent(&title, no_color));
+    lines.push(underline);
+    push_info(&mut lines, "OS", info.os.as_deref());
+    push_info(&mut lines, "Host", info.host.as_deref());
+    push_info(&mut lines, "Kernel", info.kernel.as_deref());
+    push_info(&mut lines, "Uptime", info.uptime.as_deref());
+    push_info(&mut lines, "Shell", Some(&shell));
+    push_info(&mut lines, "Terminal", Some(&terminal));
+    push_info(&mut lines, "CPU", info.cpu.as_deref());
+    push_info(&mut lines, "Memory", info.memory.as_deref());
+    lines
+}
+
+fn push_info(lines: &mut Vec<String>, label: &str, value: Option<&str>) {
+    if let Some(value) = value {
+        if !value.trim().is_empty() {
+            lines.push(format!("{label}: {value}"));
+        }
+    }
+}
+
+fn print_with_logo(lines: &[String], no_color: bool) {
+    let logo_width = WINDOWS_LOGO
+        .iter()
+        .map(|line| line.chars().count())
+        .max()
+        .unwrap_or(0);
+    let rows = WINDOWS_LOGO.len().max(lines.len());
+
+    for index in 0..rows {
+        let logo = WINDOWS_LOGO.get(index).copied().unwrap_or("");
+        let info = lines.get(index).map(String::as_str).unwrap_or("");
+        if no_color {
+            println!("{:<width$}  {}", logo, info, width = logo_width);
+        } else {
+            println!(
+                "{CYAN}{:<width$}{RESET}  {}",
+                logo,
+                info,
+                width = logo_width
+            );
+        }
+    }
+}
+
+fn terminal_name() -> String {
+    if env::var_os("WT_SESSION").is_some() {
+        return "Windows Terminal".to_string();
+    }
+    if let Ok(value) = env::var("TERM_PROGRAM") {
+        if !value.trim().is_empty() {
+            return value;
+        }
+    }
+    if let Ok(value) = env::var("TERM") {
+        if !value.trim().is_empty() {
+            return value;
+        }
+    }
+    env::var("COMSPEC").unwrap_or_else(|_| "terminal".to_string())
+}
+
+fn default_os_label() -> String {
+    if cfg!(windows) {
+        "Windows".to_string()
+    } else {
+        format!("{} {}", env::consts::OS, env::consts::ARCH)
+    }
+}
+
+fn accent(value: &str, no_color: bool) -> String {
+    if no_color {
+        value.to_string()
+    } else {
+        format!("{BOLD}{GREEN}{value}{RESET}")
+    }
+}

--- a/tests/host_contract.rs
+++ b/tests/host_contract.rs
@@ -90,6 +90,72 @@ fn slash_drive_paths_are_compat_input_not_default_output() {
 }
 
 #[test]
+fn startup_hooks_do_not_run_for_non_interactive_modes() {
+    let temp = unique_temp_dir("winuxsh-host-startup-hooks");
+    let home = temp.join("home");
+    let start = temp.join("start");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&start).unwrap();
+
+    let config = temp.join("winshrc.toml");
+    std::fs::write(
+        &config,
+        r#"
+[hooks]
+startup = ["echo SHOULD_NOT_PRINT"]
+"#,
+    )
+    .unwrap();
+    let config_env = native_path(&config);
+
+    let output = run_winuxsh(
+        "echo command-ok",
+        &start,
+        &home,
+        &[("WINUXSH_CONFIG", config_env.clone())],
+    );
+    assert_success(&output, "command-mode startup hook isolation");
+    assert_eq!(normalize_text(&output.stdout), "command-ok");
+
+    let script = temp.join("script.sh");
+    std::fs::write(&script, "echo script-ok\n").unwrap();
+    let output = Command::new(winuxsh_binary())
+        .arg(&script)
+        .current_dir(&start)
+        .env("HOME", &home)
+        .env("USERPROFILE", &home)
+        .env("ZDOTDIR", &home)
+        .env("WINUXSH_CONFIG", &config_env)
+        .output()
+        .unwrap_or_else(|err| panic!("spawn winuxsh script file: {err}"));
+    assert_success(&output, "script-file startup hook isolation");
+    assert_eq!(normalize_text(&output.stdout), "script-ok");
+
+    let mut child = Command::new(winuxsh_binary())
+        .current_dir(&start)
+        .env("HOME", &home)
+        .env("USERPROFILE", &home)
+        .env("ZDOTDIR", &home)
+        .env("WINUXSH_CONFIG", &config_env)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap_or_else(|err| panic!("spawn winuxsh stdin script: {err}"));
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(b"echo stdin-ok\n")
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert_success(&output, "stdin-script startup hook isolation");
+    assert_eq!(normalize_text(&output.stdout), "stdin-ok");
+
+    let _ = std::fs::remove_dir_all(temp);
+}
+
+#[test]
 fn native_backslash_drive_paths_work_for_winuxcmd_and_cd() {
     if !cfg!(windows) {
         return;

--- a/tests/winuxfetch.rs
+++ b/tests/winuxfetch.rs
@@ -1,0 +1,52 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+fn winuxfetch_binary() -> PathBuf {
+    let p = PathBuf::from(env!("CARGO_BIN_EXE_winuxfetch"));
+    if p.exists() {
+        return p;
+    }
+
+    let mut fallback = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    fallback.push("target");
+    fallback.push("debug");
+    fallback.push(if cfg!(windows) {
+        "winuxfetch.exe"
+    } else {
+        "winuxfetch"
+    });
+    fallback
+}
+
+#[test]
+fn winuxfetch_no_logo_prints_core_fields() {
+    let output = Command::new(winuxfetch_binary())
+        .args(["--no-logo", "--no-color"])
+        .output()
+        .expect("failed to run winuxfetch");
+
+    assert!(
+        output.status.success(),
+        "winuxfetch failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("OS:"), "{stdout}");
+    assert!(stdout.contains("Shell: winuxsh"), "{stdout}");
+    assert!(stdout.contains("Terminal:"), "{stdout}");
+}
+
+#[test]
+fn winuxfetch_license_mentions_neofetch() {
+    let output = Command::new(winuxfetch_binary())
+        .arg("--license")
+        .output()
+        .expect("failed to run winuxfetch --license");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Neofetch"), "{stdout}");
+    assert!(stdout.contains("Dylan Araps"), "{stdout}");
+}


### PR DESCRIPTION
## Summary
- add a standalone `winuxfetch` executable with Neofetch-style Windows system info and MIT attribution notice
- add `[hooks].startup` for once-per-REPL startup commands, keeping `winuxsh -c`, script files, and stdin scripts quiet
- package `winuxfetch.exe` and `THIRD_PARTY_NOTICES.md` in release zips and document opt-in usage

## Tests
- `cargo fmt` (run locally)
- `cargo build --locked`
- `$env:WINUXCMD_PATH='C:\Users\caomengxuan\tools\winuxcmd\winuxcmd.exe'; cargo test --locked`
- `target\debug\winuxfetch.exe --no-logo --no-color`
- `target\debug\winuxfetch.exe --license`