### PR TITLE
chore: pin rubash lazy call array perf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,7 +623,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 [[package]]
 name = "rubash"
 version = "0.2.0"
-source = "git+https://github.com/unixwin/rubash.git?rev=8caab03257d9902f2d5215fe9b72f05052b204a4#8caab03257d9902f2d5215fe9b72f05052b204a4"
+source = "git+https://github.com/unixwin/rubash.git?rev=e8b5b7a037754579d13b29573e7a4d6cdfba7a98#e8b5b7a037754579d13b29573e7a4d6cdfba7a98"
 dependencies = [
  "ctrlc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/unixwin/winuxsh"
 
 [dependencies]
 winuxsh-runtime = { path = "crates/winuxsh-runtime" }
-rubash = { git = "https://github.com/unixwin/rubash.git", rev = "8caab03257d9902f2d5215fe9b72f05052b204a4" }
+rubash = { git = "https://github.com/unixwin/rubash.git", rev = "e8b5b7a037754579d13b29573e7a4d6cdfba7a98" }
 anyhow = "1.0"
 env_logger = "0.10"
 log = "0.4"

--- a/DOCS/performance-investigation.md
+++ b/DOCS/performance-investigation.md
@@ -55,6 +55,10 @@ Measure-Command { bash .tmp/perf-nested-loops.sh }
   avoids process-env sync for function call state, conditionally syncs
   diagnostic line numbers, and reuses function body ASTs across calls. It was
   merged as `8caab03257d9902f2d5215fe9b72f05052b204a4`.
+- `rubash` PR #12 moved Bash call-stack arrays out of the function-call hot
+  path and materializes them only when read. It also adds a narrow fast path
+  for common assignment RHS forms like `$1` and `$((x + y))`. It was merged as
+  `e8b5b7a037754579d13b29573e7a4d6cdfba7a98`.
 
 ## 2026-07-26 benchmark snapshot
 
@@ -104,6 +108,35 @@ rubash-executor dominated, so the next profiling targets should be
 `expand_embedded_parameters`, command/function dispatch overhead that remains
 after PR #11, arithmetic evaluation, and any Windows process/environment calls
 still reached from hot shell loops.
+
+## 2026-07-26 call-stack array follow-up
+
+After `rubash` PR #12, direct `rubash` release medians improved further on the
+same 80x80 scripts:
+
+| Script | rubash baseline ms | rubash patched ms | Change |
+| --- | ---: | ---: | ---: |
+| `loop.sh` | 346.09 | 347.59 | +0.4% |
+| `arith.sh` | 401.66 | 386.89 | -3.7% |
+| `function-noop.sh` | 523.39 | 430.38 | -17.8% |
+| `function-args-arith.sh` | 824.77 | 697.68 | -15.4% |
+
+After pinning `winuxsh` to
+`rubash` `e8b5b7a037754579d13b29573e7a4d6cdfba7a98`, release medians are:
+
+| Script | Bash ms | winuxsh release ms | Median ratio |
+| --- | ---: | ---: | ---: |
+| `loop.sh` | 119.17 | 402.54 | 3.4x |
+| `arith.sh` | 139.50 | 494.38 | 3.5x |
+| `function-noop.sh` | 157.77 | 535.09 | 3.4x |
+| `function-args-arith.sh` | 209.26 | 804.35 | 3.8x |
+
+Compared with the PR #11 `winuxsh` snapshot, this reduces median wall time by
+about 28% on loop-only, 36% on arithmetic-heavy, 39% on function-noop, and 36%
+on function-plus-args-plus-arithmetic. The remaining gap is narrower but still
+large enough to keep issue #18 open; the next useful pass should use a real
+sampling profiler or narrowly scoped internal timers around command dispatch
+and arithmetic evaluation.
 
 ## Follow-up
 

--- a/crates/winuxsh-runtime/Cargo.toml
+++ b/crates/winuxsh-runtime/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0-or-later"
 description = "Runtime crate for winuxsh: rubash-backed shell REPL on Windows"
 
 [dependencies]
-rubash = { git = "https://github.com/unixwin/rubash.git", rev = "8caab03257d9902f2d5215fe9b72f05052b204a4" }
+rubash = { git = "https://github.com/unixwin/rubash.git", rev = "e8b5b7a037754579d13b29573e7a4d6cdfba7a98" }
 reedline = "0.33"
 anyhow = "1.0"
 thiserror = "1.0"


### PR DESCRIPTION
## Summary
- Pin `rubash` to `e8b5b7a037754579d13b29573e7a4d6cdfba7a98`, which includes unixwin/rubash#12.
- Update the performance investigation note for issue #18 with the call-stack array follow-up.
- Keep issue #18 open because release `winuxsh` is still about 3.4-3.8x slower than Git Bash on the 80x80 microbenchmarks.

## Benchmark snapshot
Post-upgrade release medians, 7 runs each after warmup:

| Script | Bash ms | winuxsh release ms | Median ratio |
| --- | ---: | ---: | ---: |
| `loop.sh` | 119.17 | 402.54 | 3.4x |
| `arith.sh` | 139.50 | 494.38 | 3.5x |
| `function-noop.sh` | 157.77 | 535.09 | 3.4x |
| `function-args-arith.sh` | 209.26 | 804.35 | 3.8x |

Compared with the previous #29 snapshot, this reduces median wall time by about 28% on loop-only, 36% on arithmetic-heavy, 39% on function-noop, and 36% on function-plus-args-plus-arithmetic.

## Tests
- `cargo check --locked`
- `cargo test --locked`
- `cargo build --release --locked`