### PR TITLE
fix: render prompt time from local system clock

### DIFF
--- a/crates/winuxsh-runtime/Cargo.toml
+++ b/crates/winuxsh-runtime/Cargo.toml
@@ -28,7 +28,7 @@ globset = "0.4"
 glob = "0.3"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_Console", "Win32_System_Threading"] }
+windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_Console", "Win32_System_SystemInformation", "Win32_System_Threading"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/winuxsh-runtime/src/prompt.rs
+++ b/crates/winuxsh-runtime/src/prompt.rs
@@ -178,12 +178,8 @@ impl WinuxshPrompt {
             }
         };
 
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
-        let time_str = format_time(now);
-        let time_str_24 = format_time_24(now);
+        let time_str = format_local_time();
+        let time_str_24 = time_str.clone();
 
         template
             .replace("{time}", &time_str)
@@ -276,18 +272,32 @@ impl WinuxshPrompt {
     }
 }
 
-fn format_time(unix_secs: u64) -> String {
-    let secs = unix_secs % 86400;
-    let hours = secs / 3600;
-    let mins = (secs % 3600) / 60;
+pub(crate) fn format_local_time() -> String {
+    let (hours, mins) = local_hour_minute();
     format!("{:02}:{:02}", hours, mins)
 }
 
-fn format_time_24(unix_secs: u64) -> String {
-    let secs = unix_secs % 86400;
-    let hours = secs / 3600;
-    let mins = (secs % 3600) / 60;
-    format!("{:02}:{:02}", hours, mins)
+#[cfg(windows)]
+fn local_hour_minute() -> (u32, u32) {
+    use windows_sys::Win32::Foundation::SYSTEMTIME;
+    use windows_sys::Win32::System::SystemInformation::GetLocalTime;
+
+    let mut local_time = std::mem::MaybeUninit::<SYSTEMTIME>::zeroed();
+    unsafe {
+        GetLocalTime(local_time.as_mut_ptr());
+        let local_time = local_time.assume_init();
+        (local_time.wHour as u32, local_time.wMinute as u32)
+    }
+}
+
+#[cfg(not(windows))]
+fn local_hour_minute() -> (u32, u32) {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let secs = now % 86400;
+    ((secs / 3600) as u32, ((secs % 3600) / 60) as u32)
 }
 
 #[allow(dead_code)]
@@ -438,6 +448,19 @@ mod tests {
         let prompt = WinuxshPrompt::new(Some("left> ".to_string()), None, None, "default");
 
         assert_eq!(prompt.render_prompt_right(), "");
+    }
+
+    #[test]
+    fn time_tokens_render_system_local_clock() {
+        let prompt =
+            WinuxshPrompt::new(Some("{time} {time_24}".to_string()), None, None, "default");
+
+        let rendered = prompt.render_prompt_left();
+        let expected = format_local_time();
+        if rendered != format!("{expected} {expected}") {
+            let expected = format_local_time();
+            assert_eq!(rendered, format!("{expected} {expected}"));
+        }
     }
 
     #[test]

--- a/crates/winuxsh-runtime/src/prompt_segments.rs
+++ b/crates/winuxsh-runtime/src/prompt_segments.rs
@@ -15,7 +15,7 @@ use nu_ansi_term::{Color, Style};
 use reedline::{Prompt, PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus};
 
 use crate::git_status::{collect_for_prompt, GitPromptSymbols, GitRepoStatus};
-use crate::prompt::PromptIndicators;
+use crate::prompt::{format_local_time, PromptIndicators};
 
 // ---- Segment identifiers ----
 
@@ -212,16 +212,7 @@ fn render_content(
                 Some(format!("\u{2718} {}", code))
             }
         }
-        SegmentId::Time => {
-            let now = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_secs())
-                .unwrap_or(0);
-            let secs = now % 86400;
-            let hours = secs / 3600;
-            let mins = (secs % 3600) / 60;
-            Some(format!("{:02}:{:02}", hours, mins))
-        }
+        SegmentId::Time => Some(format_local_time()),
         SegmentId::PromptChar => Some(config.prompt_symbol.clone()),
         SegmentId::OsIcon => Some("\u{1f4bb}".to_string()),
         SegmentId::Context => {
@@ -675,6 +666,17 @@ mod tests {
         let s = content.unwrap();
         assert_eq!(s.len(), 5);
         assert_eq!(&s[2..3], ":");
+    }
+
+    #[test]
+    fn time_segment_renders_system_local_clock() {
+        let cfg = default_cfg();
+        let content = render_content(&SegmentId::Time, None, &cfg).unwrap();
+        let expected = format_local_time();
+        if content != expected {
+            let expected = format_local_time();
+            assert_eq!(content, expected);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- render prompt time from Windows local system clock instead of UTC seconds
- reuse the same local time helper for prompt templates and segment prompts
- keep version at 0.9.3; no tag or release changes

## Tests
- cargo fmt --check
- cargo check --workspace --locked
- cargo test -p winuxsh-runtime --lib time_tokens_render_system_local_clock --locked
- cargo test -p winuxsh-runtime --lib time_segment_renders_system_local_clock --locked