### PR TITLE
Harden plugin asset catalogs

### DIFF
--- a/DOCS/plugin-externalization-readiness.md
+++ b/DOCS/plugin-externalization-readiness.md
@@ -19,12 +19,15 @@ this matrix to decide whether a pack belongs in `source`, `process`, `wasm`,
 - Process plugins can expose commands, lifecycle hooks, and the command-not-found provider binding. Hook stdout is
   not a structured effect protocol for mutating shell state.
 - Static assets do not need WASM. Aliases, completion tables, prompt presets,
-  keybinding metadata, and themes should be separated from "builtin behavior"
-  before moving behavior into WASM or process runtimes.
+  keybinding metadata, and themes are bundle-owned assets consumed by the
+  Winuxsh host. They are not sourced as shell code and they are not blocked on
+  a WASM ABI.
 - `plugin list`, `plugin info`, `plugin search`, `plugin review`, and
   `plugin doctor` expose derived `execution_model`, `externalization_class`,
   and readiness profile values. These are review surfaces, not manifest schema
   fields.
+- `plugin prompts`, `plugin keybindings`, and `plugin themes` expose the
+  concrete asset catalogs the host can consume at runtime.
 ## Classification Terms
 | Classification | Meaning |
 | --- | --- |
@@ -38,30 +41,31 @@ this matrix to decide whether a pack belongs in `source`, `process`, `wasm`,
 ## Readiness Matrix
 | Pack | Current runtime | Classification | Target runtime / execution model | Missing host API or decision | Shell-mutating | Fallback needed |
 | --- | --- | --- | --- | --- | --- | --- |
-| `git` | `source` | Shell source plus mixed declarative/native | `.winux` startup helpers plus alias/completion assets; native prompt segment until prompt provider ABI | Prompt segment provider ABI for dynamic git status | Yes, by trusted startup source | Yes, compiled prompt segment fallback |
+| `git` | `source` | Shell source plus mixed declarative/native | `.winux` startup helpers plus alias/completion assets; native git prompt segment remains host-owned | None for current first-party source/helper scope | Yes, by trusted startup source | No |
 | `docker` | `source` | Shell source plus declarative asset | `.winux` helper functions plus alias/completion assets | None for current first-party source helper scope | Yes, by trusted startup source | Minimal, existing compiled aliases/completions |
 | `kubectl` | `source` | Shell source plus declarative asset | `.winux` helper functions plus alias/completion assets | None for current first-party source helper scope | Yes, by trusted startup source | Minimal |
-| `npm` | `source` | Shell source plus mixed declarative/native | `.winux` helper functions plus assets; native/dynamic completion until completion provider ABI | Completion/provider ABI if dynamic npm completion remains host-owned | Yes, by trusted startup source | Yes |
+| `npm` | `source` | Shell source plus mixed declarative/native | `.winux` helper functions plus assets; native/dynamic completion remains host-owned | None for current first-party source/helper scope | Yes, by trusted startup source | No |
 | `zoxide` | `builtin` | Shell-effect candidate | Native builtin now; future effect runtime only after cwd effects are explicit | `shell:cwd:write`, lifecycle context, rollback/failure behavior | Yes | Yes |
 | `direnv` | `builtin` | Shell-effect candidate | Native builtin now; future effect runtime only after env writes are structured | `env:write`, scoped process adapter policy, lifecycle context, rollback/failure behavior | Yes | Yes |
 | `dotenv` | `builtin` | Shell-effect candidate | Native builtin now; future effect runtime only after fs/env effects are structured | Scoped `fs:read`, `env:write`, lifecycle context, rollback/failure behavior | Yes | Yes |
 | `fzf` | `builtin` | External-tool adapter plus shell effect | Native builtin now; future process/effect only after interactive policy | Interactive process policy, `shell:cwd:write`, rollback/failure behavior | Yes | Yes |
-| `command-not-found` | `builtin` | Pure provider candidate | Process provider binding exists; official pack can stay builtin until migration; future WASM provider must use separate ABI | Bundle migration decision plus future WASM provider entrypoint | No | Yes |
+| `command-not-found` | `builtin` | Pure provider candidate | Host call-site and process-provider bridge are implemented; future WASM provider must use a separate ABI | `wasm_provider_abi` | No | Yes |
 | `last-working-dir` | `builtin` | Shell-effect candidate | Native builtin now; future effect runtime only after cache/cwd protocol | Scoped cache read/write, startup/chpwd effect protocol, `shell:cwd:write` | Yes | Yes |
 | `thefuck` | `builtin` | External-tool adapter plus shell effect | Native/process adapter plus future effect protocol; hold now | `history:read`, suggested command review/execute protocol, process adapter policy | Yes | Yes |
-| `keybindings` | `builtin` | Declarative asset | Asset-only/declarative; schema marker TBD | Schema decision: asset-only marker; reedline actions stay native | No | Minimal |
-| `prompts` | `builtin` | Mixed declarative/native | Declarative prompt presets plus native segments until prompt provider ABI | Prompt segment provider ABI for dynamic values | No | Yes |
-| `themes` | `builtin` | Declarative asset | Asset-only/declarative; schema marker TBD | Schema decision: asset-only marker; theme renderer stays native | No | Minimal |
+| `keybindings` | `builtin` | Declarative asset | Declarative bundle asset plus native Reedline action mapping | None | No | No |
+| `prompts` | `builtin` | Mixed declarative/native | Declarative prompt presets plus native prompt segments | None | No | No |
+| `themes` | `builtin` | Declarative asset | Declarative bundle asset plus native theme renderer | None | No | No |
 | `process-echo` | `process` | Fixture | Process command fixture | None for current fixture scope | No | No |
 | `process-hook` | `process` | Fixture | Process hook fixture; not a generic effect runtime | Structured hook effects before using as normal shell-mutating pack | No in fixture | No |
 | `wasm-hello` | `wasm` | Fixture | WASM command fixture; provider/effect ABI is separate | Provider/effect ABI is separate future work | No | No |
 ## Immediate Decision Gates
 1. Use `source` when the plugin's value is shell startup behavior and the
    `shell:source` trust tradeoff is acceptable.
-2. Separate declarative assets from host-owned behavior in naming and docs
-   before changing manifest schema.
-3. Choose the asset-only representation only after checking bundle schema,
-   index validation, compiled fallback inventory, and compatibility docs.
+2. Keep declarative assets separate from shell source. Prompt presets, themes,
+   and keybindings are read from bundle assets and applied by Winuxsh/Reedline.
+3. Do not block first-party asset packs on a new runtime kind. The current
+   manifest exports plus bundle layout are sufficient; add a new asset-only
+   schema only if third-party compatibility requires it.
 4. Use the implemented process-provider binding around
    [command-not-found](plugin-command-not-found-provider-abi.md):
    verify missing-command input, host context, deterministic suggestion output, and fallback before migrating the official pack.

--- a/crates/winuxsh-runtime/src/plugins/mod.rs
+++ b/crates/winuxsh-runtime/src/plugins/mod.rs
@@ -1,7 +1,10 @@
 //! Winuxsh-native plugin inventory, bundle assets, and plugin CLI helpers.
 use crate::completion::external::{CommandDef, FlagDef, SubcommandDef};
 use crate::config::{PluginConfig, ZshConfig};
+use crate::git_status::GitPromptSymbols;
+use crate::prompt_segments::{SegmentId, SegmentPreset, SegmentPromptConfig};
 use crate::theme::Theme;
+use crate::zsh_compat::NativeWidgetSuggestion;
 use anyhow::{anyhow, Context};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -316,6 +319,42 @@ pub struct PluginThemeCatalogEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<PathBuf>,
 }
+#[derive(Debug, Clone, Serialize)]
+pub struct PluginPromptCatalogEntry {
+    pub name: String,
+    pub source: String,
+    pub trust_source: String,
+    pub owner: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bundle: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pack: Option<String>,
+    #[serde(flatten)]
+    pub preset: PromptPresetAsset,
+}
+#[derive(Debug, Clone, Serialize)]
+pub struct PluginKeybindingCatalogEntry {
+    pub name: String,
+    pub source: String,
+    pub trust_source: String,
+    pub owner: String,
+    pub keymap: String,
+    pub summary: String,
+    pub bindings: Vec<PluginKeybindingCatalogBinding>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bundle: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pack: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<PathBuf>,
+}
+#[derive(Debug, Clone, Serialize)]
+pub struct PluginKeybindingCatalogBinding {
+    pub key: String,
+    pub action: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
 #[derive(Debug, Deserialize)]
 struct BundleToml {
     name: String,
@@ -500,11 +539,12 @@ struct BundleKeybindingsToml {
     #[serde(default)]
     bindings: Vec<BundleKeybindingToml>,
 }
-#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct BundleKeybindingToml {
     key: String,
     action: String,
+    #[serde(default)]
+    description: Option<String>,
 }
 pub fn effective_plugin_state(config: &PluginConfig, zsh: &ZshConfig) -> PluginRuntimeState {
     let mut state = PluginRuntimeState::default();
@@ -972,10 +1012,10 @@ fn plugin_readiness_profile(pack: &PluginPackRecord) -> PluginReadinessProfile {
     match pack.name.as_str() {
         "git" => readiness(
             "source_assets_plus_native_prompt_segment",
-            "prompt_segment_provider_abi",
+            "none",
             false,
-            true,
-            "compiled_prompt_segment",
+            false,
+            "none",
         ),
         "docker" => readiness(
             "current_shell_source_plus_declarative_assets",
@@ -993,10 +1033,10 @@ fn plugin_readiness_profile(pack: &PluginPackRecord) -> PluginReadinessProfile {
         ),
         "npm" => readiness(
             "source_assets_plus_native_dynamic_completion",
-            "completion_provider_abi",
+            "none",
             false,
-            true,
-            "native_dynamic_completion",
+            false,
+            "none",
         ),
         "zoxide" => readiness(
             "native_until_effect_runtime",
@@ -1027,8 +1067,8 @@ fn plugin_readiness_profile(pack: &PluginPackRecord) -> PluginReadinessProfile {
             "native_builtin",
         ),
         "command-not-found" => readiness(
-            "process_provider_available_builtin_until_migration",
-            "bundle_migration_decision,wasm_provider_abi",
+            "host_builtin_and_process_provider",
+            "wasm_provider_abi",
             false,
             true,
             "compiled_native_hints",
@@ -1048,25 +1088,25 @@ fn plugin_readiness_profile(pack: &PluginPackRecord) -> PluginReadinessProfile {
             "native_builtin",
         ),
         "keybindings" => readiness(
-            "asset_only_declarative_schema_tbd",
-            "asset_only_schema_marker,reedline_actions_stay_native",
+            "declarative_asset_plus_native_reedline_actions",
+            "none",
             false,
-            true,
-            "native_reedline_actions",
+            false,
+            "none",
         ),
         "prompts" => readiness(
             "declarative_presets_plus_native_segments",
-            "prompt_segment_provider_abi",
+            "none",
             false,
-            true,
-            "native_prompt_segments",
+            false,
+            "none",
         ),
         "themes" => readiness(
-            "asset_only_declarative_schema_tbd",
-            "asset_only_schema_marker,theme_renderer_stays_native",
+            "declarative_asset_plus_native_theme_renderer",
+            "none",
             false,
-            true,
-            "native_theme_renderer",
+            false,
+            "none",
         ),
         "process-echo" => readiness("process_command_fixture", "none", false, false, "none"),
         "process-hook" => readiness(
@@ -1085,11 +1125,11 @@ fn plugin_readiness_profile(pack: &PluginPackRecord) -> PluginReadinessProfile {
         ),
         _ => match plugin_externalization_class(pack) {
             "declarative_asset" => readiness(
-                "asset_only_declarative_schema_tbd",
-                "asset_only_schema_marker",
+                "declarative_asset_plus_host_consumer",
+                "none",
                 false,
-                true,
-                "compiled_or_bundle_asset_fallback",
+                false,
+                "none",
             ),
             "shell_effect_candidate" => readiness(
                 "native_until_effect_runtime",
@@ -1613,7 +1653,7 @@ pub fn plugin_permission_review(
             "Mixed pack: static bundle assets are declarative, while dynamic behavior remains Winuxsh-owned.".to_string(),
         ),
         "pure_provider_candidate" => notes.push(
-            "Provider candidate; process provider binding exists for command-not-found, while WASM providers still require a separate ABI.".to_string(),
+            "Provider pack; command-not-found is wired to the host call-site and process-provider bridge. WASM providers still need a separate ABI.".to_string(),
         ),
         "shell_effect_candidate" => notes.push(
             "Shell-effect pack remains host-owned until env/cwd/history effects are explicit and permissioned.".to_string(),
@@ -2662,6 +2702,111 @@ pub fn plugin_prompt_preset(name: &str) -> Option<PromptPresetAsset> {
         .find(|(candidate, _)| candidate.eq_ignore_ascii_case(name))
         .map(|(_, preset)| resolve_prompt_segment_refs(preset, &parsed.segments))
 }
+pub fn plugin_prompt_catalog_json() -> anyhow::Result<String> {
+    Ok(serde_json::to_string_pretty(&plugin_prompt_catalog())?)
+}
+pub fn plugin_prompt_catalog_text() -> String {
+    let mut out = String::new();
+    out.push_str("Winuxsh prompt presets\n");
+    out.push_str("Sources: built-in presets and active bundle assets\n");
+    for entry in plugin_prompt_catalog() {
+        out.push_str(&format!(
+            "- {} source={} owner={}",
+            entry.name, entry.source, entry.owner
+        ));
+        if let Some(bundle) = entry.bundle {
+            out.push_str(&format!(" bundle={bundle}"));
+        }
+        if let Some(pack) = entry.pack {
+            out.push_str(&format!(" pack={pack}"));
+        }
+        out.push_str(&format!(" trust_source={}", entry.trust_source));
+        out.push_str(&format!(
+            " left={} right={} separator={:?}",
+            list_or_none(&entry.preset.left_elements),
+            list_or_none(&entry.preset.right_elements),
+            entry.preset.separator
+        ));
+        if let Some(git_format) = entry.preset.git_prompt_format {
+            out.push_str(&format!(" git_prompt_format={git_format:?}"));
+        }
+        out.push('\n');
+    }
+    out
+}
+pub fn plugin_prompt_catalog() -> Vec<PluginPromptCatalogEntry> {
+    let mut entries = SegmentPreset::names()
+        .iter()
+        .filter_map(|name| builtin_prompt_preset_catalog_entry(name))
+        .collect::<Vec<_>>();
+    let inventory = active_plugin_inventory();
+    let Some(root) = &inventory.path else {
+        return entries;
+    };
+    let Some(parsed) = load_bundle_prompt_segments_from_path(root) else {
+        return entries;
+    };
+    let pack_name = inventory
+        .packs
+        .iter()
+        .find(|pack| !pack.exports.prompt_segments.is_empty() && pack.name == "prompts")
+        .or_else(|| {
+            inventory
+                .packs
+                .iter()
+                .find(|pack| !pack.exports.prompt_segments.is_empty())
+        })
+        .map(|pack| pack.name.clone());
+    for (name, preset) in parsed.presets {
+        entries.push(PluginPromptCatalogEntry {
+            name,
+            source: "bundle".to_string(),
+            trust_source: inventory.trust_source.clone(),
+            owner: format!("{}@{}", inventory.bundle, inventory.version),
+            bundle: Some(inventory.bundle.clone()),
+            pack: pack_name.clone(),
+            preset: resolve_prompt_segment_refs(preset, &parsed.segments),
+        });
+    }
+    entries
+}
+fn builtin_prompt_preset_catalog_entry(name: &str) -> Option<PluginPromptCatalogEntry> {
+    let preset = SegmentPreset::from_name(name)?;
+    let config = SegmentPromptConfig::from_preset(preset, "%", GitPromptSymbols::default());
+    Some(PluginPromptCatalogEntry {
+        name: name.to_string(),
+        source: "builtin".to_string(),
+        trust_source: "builtin".to_string(),
+        owner: "winuxsh".to_string(),
+        bundle: None,
+        pack: None,
+        preset: PromptPresetAsset {
+            left_elements: segment_names(&config.left_elements),
+            right_elements: segment_names(&config.right_elements),
+            separator: config.separator,
+            git_prompt_format: config.git_prompt_format,
+        },
+    })
+}
+fn segment_names(segments: &[SegmentId]) -> Vec<String> {
+    segments.iter().map(segment_name).collect()
+}
+fn segment_name(segment: &SegmentId) -> String {
+    match segment {
+        SegmentId::Dir => "dir",
+        SegmentId::Vcs => "vcs",
+        SegmentId::Status => "status",
+        SegmentId::Time => "time",
+        SegmentId::PromptChar => "prompt_char",
+        SegmentId::OsIcon => "os_icon",
+        SegmentId::Context => "context",
+        SegmentId::BackgroundJobs => "background_jobs",
+        SegmentId::CommandExecutionTime => "command_execution_time",
+        SegmentId::Newline => "newline",
+        SegmentId::Custom(name) => name,
+    }
+    .to_string()
+}
 fn load_bundle_prompt_segments_from_path(root: &Path) -> Option<BundlePromptSegmentsToml> {
     let path = bundle_asset_path(root, "prompts", "segments", "toml")?;
     let text = fs::read_to_string(path).ok()?;
@@ -2694,7 +2839,7 @@ pub fn plugin_theme_catalog_json() -> anyhow::Result<String> {
 pub fn plugin_theme_catalog_text() -> String {
     let mut out = String::new();
     out.push_str("Winuxsh themes\n");
-    out.push_str("Resolution order: builtin > user > active bundle\n");
+    out.push_str("Sources: built-in themes, user themes, and active bundle assets\n");
     for entry in plugin_theme_catalog() {
         out.push_str(&format!(
             "- {} source={} owner={}",
@@ -2788,6 +2933,109 @@ fn load_bundle_theme_from_path(root: &Path, name: &str) -> Option<Theme> {
     let path = bundle_asset_path(root, "themes", name, "toml")?;
     crate::theme::load_theme_from_file(name, &path)
 }
+pub fn plugin_keybinding_catalog_json() -> anyhow::Result<String> {
+    Ok(serde_json::to_string_pretty(&plugin_keybinding_catalog())?)
+}
+pub fn plugin_keybinding_catalog_text() -> String {
+    let mut out = String::new();
+    out.push_str("Winuxsh keybindings\n");
+    out.push_str("Sources: Reedline defaults plus active bundle keybinding assets\n");
+    for entry in plugin_keybinding_catalog() {
+        out.push_str(&format!(
+            "- {} keymap={} source={} owner={} bindings={}",
+            entry.name,
+            entry.keymap,
+            entry.source,
+            entry.owner,
+            entry.bindings.len()
+        ));
+        if let Some(bundle) = &entry.bundle {
+            out.push_str(&format!(" bundle={bundle}"));
+        }
+        if let Some(pack) = &entry.pack {
+            out.push_str(&format!(" pack={pack}"));
+        }
+        if let Some(path) = &entry.path {
+            out.push_str(&format!(" path={}", path.display()));
+        }
+        out.push_str(&format!(" trust_source={}", entry.trust_source));
+        out.push_str(&format!(" summary={:?}\n", entry.summary));
+        for binding in &entry.bindings {
+            out.push_str(&format!("  {} -> {}", binding.key, binding.action));
+            if let Some(description) = &binding.description {
+                out.push_str(&format!(" ({description})"));
+            }
+            out.push('\n');
+        }
+    }
+    out
+}
+pub fn plugin_keybinding_catalog() -> Vec<PluginKeybindingCatalogEntry> {
+    let inventory = active_plugin_inventory();
+    let Some(root) = &inventory.path else {
+        return Vec::new();
+    };
+    let mut entries = Vec::new();
+    for pack in &inventory.packs {
+        for name in &pack.exports.keybindings {
+            let Some((metadata, path)) = load_bundle_keybindings_with_path(root, name) else {
+                continue;
+            };
+            entries.push(PluginKeybindingCatalogEntry {
+                name: metadata.name,
+                source: "bundle".to_string(),
+                trust_source: inventory.trust_source.clone(),
+                owner: format!("{}@{}", inventory.bundle, inventory.version),
+                keymap: metadata.keymap,
+                summary: metadata.summary,
+                bindings: metadata
+                    .bindings
+                    .into_iter()
+                    .map(|binding| PluginKeybindingCatalogBinding {
+                        key: binding.key,
+                        action: binding.action,
+                        description: binding.description,
+                    })
+                    .collect(),
+                bundle: Some(inventory.bundle.clone()),
+                pack: Some(pack.name.clone()),
+                path: Some(path),
+            });
+        }
+    }
+    entries
+}
+pub fn plugin_keybinding_suggestions() -> Vec<NativeWidgetSuggestion> {
+    plugin_keybinding_catalog()
+        .into_iter()
+        .flat_map(|entry| {
+            let keymap = plugin_keymap_to_native_keymap(&entry.keymap);
+            let origin = format!("plugin:{}", entry.name);
+            let source_file = entry.path.clone();
+            entry
+                .bindings
+                .into_iter()
+                .map(move |binding| NativeWidgetSuggestion {
+                    widget: binding.action,
+                    function: None,
+                    key: Some(binding.key),
+                    keymap: keymap.clone(),
+                    source_file: source_file.clone(),
+                    line: None,
+                    origin: origin.clone(),
+                })
+        })
+        .collect()
+}
+fn plugin_keymap_to_native_keymap(keymap: &str) -> Option<String> {
+    match keymap.to_ascii_lowercase().as_str() {
+        "all" | "main" => Some("main".to_string()),
+        "emacs" => Some("emacs".to_string()),
+        "vi" | "vi-normal" | "vi_normal" | "vicmd" => Some("vicmd".to_string()),
+        "vi-insert" | "vi_insert" | "viins" => Some("viins".to_string()),
+        _ => None,
+    }
+}
 fn plugin_keybinding_metadata_lines(
     inventory: &PluginInventory,
     pack: &PluginPackRecord,
@@ -2811,9 +3059,16 @@ fn plugin_keybinding_metadata_lines(
         .collect()
 }
 fn load_bundle_keybindings_from_path(root: &Path, name: &str) -> Option<BundleKeybindingsToml> {
+    load_bundle_keybindings_with_path(root, name).map(|(metadata, _)| metadata)
+}
+fn load_bundle_keybindings_with_path(
+    root: &Path,
+    name: &str,
+) -> Option<(BundleKeybindingsToml, PathBuf)> {
     let path = bundle_asset_path(root, "keybindings", name, "toml")?;
-    let text = fs::read_to_string(path).ok()?;
-    toml::from_str(&text).ok()
+    let text = fs::read_to_string(&path).ok()?;
+    let metadata = toml::from_str(&text).ok()?;
+    Some((metadata, path))
 }
 fn bundle_asset_path(
     root: &Path,

--- a/crates/winuxsh-runtime/src/repl.rs
+++ b/crates/winuxsh-runtime/src/repl.rs
@@ -259,6 +259,7 @@ fn native_widget_event(widget: &str) -> Option<ReedlineEvent> {
         "clear-screen" => Some(ReedlineEvent::ClearScreen),
         "redisplay" => Some(ReedlineEvent::Repaint),
         "expand-or-complete" | "complete-word" => Some(completion_event()),
+        "menu-previous" => Some(ReedlineEvent::MenuPrevious),
         "history-incremental-search-backward" => Some(ReedlineEvent::SearchHistory),
         "up-line-or-history" => Some(ReedlineEvent::Up),
         "down-line-or-history" => Some(ReedlineEvent::Down),
@@ -278,6 +279,9 @@ fn completion_event() -> ReedlineEvent {
 }
 
 fn parse_zsh_key_sequence(value: &str) -> Option<(KeyModifiers, KeyCode)> {
+    if let Some(key) = parse_named_key_sequence(value) {
+        return Some(key);
+    }
     match value {
         "^[[A" | "\\e[A" | "\\eOA" => Some((KeyModifiers::NONE, KeyCode::Up)),
         "^[[B" | "\\e[B" | "\\eOB" => Some((KeyModifiers::NONE, KeyCode::Down)),
@@ -288,6 +292,47 @@ fn parse_zsh_key_sequence(value: &str) -> Option<(KeyModifiers, KeyCode)> {
             .or_else(|| parse_control_key_sequence(value))
             .or_else(|| parse_plain_key_sequence(value)),
     }
+}
+
+fn parse_named_key_sequence(value: &str) -> Option<(KeyModifiers, KeyCode)> {
+    let normalized = value
+        .trim()
+        .to_ascii_lowercase()
+        .replace("control+", "ctrl+")
+        .replace("option+", "alt+");
+    match normalized.as_str() {
+        "tab" => return Some((KeyModifiers::NONE, KeyCode::Tab)),
+        "shift+tab" | "backtab" => return Some((KeyModifiers::SHIFT, KeyCode::BackTab)),
+        "esc" | "escape" => return Some((KeyModifiers::NONE, KeyCode::Esc)),
+        "enter" | "return" => return Some((KeyModifiers::NONE, KeyCode::Enter)),
+        "space" => return Some((KeyModifiers::NONE, KeyCode::Char(' '))),
+        "backspace" => return Some((KeyModifiers::NONE, KeyCode::Backspace)),
+        "delete" | "del" => return Some((KeyModifiers::NONE, KeyCode::Delete)),
+        "up" => return Some((KeyModifiers::NONE, KeyCode::Up)),
+        "down" => return Some((KeyModifiers::NONE, KeyCode::Down)),
+        "left" => return Some((KeyModifiers::NONE, KeyCode::Left)),
+        "right" => return Some((KeyModifiers::NONE, KeyCode::Right)),
+        _ => {}
+    }
+    parse_modified_named_key(&normalized, "ctrl+", KeyModifiers::CONTROL)
+        .or_else(|| parse_modified_named_key(&normalized, "alt+", KeyModifiers::ALT))
+}
+
+fn parse_modified_named_key(
+    value: &str,
+    prefix: &str,
+    modifiers: KeyModifiers,
+) -> Option<(KeyModifiers, KeyCode)> {
+    let rest = value.strip_prefix(prefix)?;
+    if rest == "space" {
+        return Some((modifiers, KeyCode::Char(' ')));
+    }
+    let mut chars = rest.chars();
+    let ch = chars.next()?;
+    if chars.next().is_some() {
+        return None;
+    }
+    Some((modifiers, KeyCode::Char(ch)))
 }
 
 fn parse_alt_key_sequence(value: &str) -> Option<(KeyModifiers, KeyCode)> {
@@ -957,6 +1002,41 @@ mod tests {
         assert_eq!(
             keybindings.find_binding(KeyModifiers::CONTROL, KeyCode::Char(' ')),
             Some(ReedlineEvent::HistoryHintComplete)
+        );
+    }
+
+    #[test]
+    fn native_widget_imports_named_bundle_key_syntax() {
+        let mut keybindings = default_emacs_keybindings();
+        let config = NativeWidgetConfig {
+            enabled: true,
+            presets: Vec::new(),
+            import_bindkeys: true,
+        };
+        let bindings = vec![
+            native_widget_binding("Ctrl+A", Some("emacs"), "beginning-of-line"),
+            native_widget_binding("Alt+B", Some("emacs"), "backward-word"),
+            native_widget_binding("Shift+Tab", Some("emacs"), "menu-previous"),
+        ];
+
+        add_native_widget_keybindings(
+            &mut keybindings,
+            NativeKeymapTarget::Emacs,
+            &config,
+            &bindings,
+        );
+
+        assert_eq!(
+            keybindings.find_binding(KeyModifiers::CONTROL, KeyCode::Char('a')),
+            Some(edit_event(EditCommand::MoveToLineStart { select: false }))
+        );
+        assert_eq!(
+            keybindings.find_binding(KeyModifiers::ALT, KeyCode::Char('b')),
+            Some(edit_event(EditCommand::MoveWordLeft { select: false }))
+        );
+        assert_eq!(
+            keybindings.find_binding(KeyModifiers::SHIFT, KeyCode::BackTab),
+            Some(ReedlineEvent::MenuPrevious)
         );
     }
 

--- a/crates/winuxsh-runtime/src/shell.rs
+++ b/crates/winuxsh-runtime/src/shell.rs
@@ -327,7 +327,8 @@ impl Shell {
             native_widgets.enabled = false;
             native_widgets.presets.clear();
         }
-        let native_widget_bindings = if native_widgets.enabled && native_widgets.import_bindkeys {
+        let mut native_widget_bindings = if native_widgets.enabled && native_widgets.import_bindkeys
+        {
             zsh_report
                 .as_ref()
                 .map(|report| report.native_widgets.clone())
@@ -335,6 +336,17 @@ impl Shell {
         } else {
             Vec::new()
         };
+        if plugin_state.is_enabled("keybindings") {
+            let plugin_keybindings = crate::plugins::plugin_keybinding_suggestions();
+            if !plugin_keybindings.is_empty() {
+                if !native_widgets.enabled {
+                    native_widgets.presets.clear();
+                }
+                native_widgets.enabled = true;
+                native_widgets.import_bindkeys = true;
+                native_widget_bindings.extend(plugin_keybindings);
+            }
+        }
 
         let mut shell = Self {
             executor,

--- a/src/main.rs
+++ b/src/main.rs
@@ -313,6 +313,8 @@ fn print_usage() {
     println!("  plugin list [--json]      List official Winuxsh plugins");
     println!("  plugin info <name> [--json]  Inspect one official Winuxsh plugin");
     println!("  plugin search [query] [--json]  Discover official plugins");
+    println!("  plugin prompts [--json]   List built-in and bundle prompt presets");
+    println!("  plugin keybindings [--json]  List bundle keybinding presets");
     println!("  plugin themes [--json]    List built-in, user, and bundle themes");
     println!("  plugin bundle status [--json]  Inspect official bundle install state");
     println!("  plugin update oh-my-winuxsh --from <path>");
@@ -365,6 +367,8 @@ fn run_plugin_command(args: &[String]) -> anyhow::Result<()> {
             Ok(())
         }
         "search" => run_plugin_search_command(&args[3..]),
+        "prompts" => run_plugin_prompts_command(&args[3..]),
+        "keybindings" => run_plugin_keybindings_command(&args[3..]),
         "themes" => run_plugin_themes_command(&args[3..]),
         "info" => {
             let Some(name) = args.get(3) else {
@@ -455,6 +459,35 @@ fn run_plugin_themes_command(args: &[String]) -> anyhow::Result<()> {
         println!("{}", winuxsh_runtime::plugins::plugin_theme_catalog_json()?);
     } else {
         println!("{}", winuxsh_runtime::plugins::plugin_theme_catalog_text());
+    }
+    Ok(())
+}
+
+fn run_plugin_prompts_command(args: &[String]) -> anyhow::Result<()> {
+    let json = parse_plugin_json_flag(args)?;
+    if json {
+        println!(
+            "{}",
+            winuxsh_runtime::plugins::plugin_prompt_catalog_json()?
+        );
+    } else {
+        println!("{}", winuxsh_runtime::plugins::plugin_prompt_catalog_text());
+    }
+    Ok(())
+}
+
+fn run_plugin_keybindings_command(args: &[String]) -> anyhow::Result<()> {
+    let json = parse_plugin_json_flag(args)?;
+    if json {
+        println!(
+            "{}",
+            winuxsh_runtime::plugins::plugin_keybinding_catalog_json()?
+        );
+    } else {
+        println!(
+            "{}",
+            winuxsh_runtime::plugins::plugin_keybinding_catalog_text()
+        );
     }
     Ok(())
 }
@@ -862,6 +895,8 @@ fn print_plugin_usage() {
     println!("  list [--json]             List official Winuxsh plugins");
     println!("  info <name> [--json]      Inspect one official Winuxsh plugin");
     println!("  search [query] [--json]   Discover official plugins");
+    println!("  prompts [--json]          List built-in and bundle prompt presets");
+    println!("  keybindings [--json]      List bundle keybinding presets");
     println!("  themes [--json]           List built-in, user, and bundle themes");
     println!("  bundle status [--json]    Inspect official bundle install state");
     println!("  doctor [--json]           Diagnose plugin configuration health");

--- a/tests/plugin_inventory.rs
+++ b/tests/plugin_inventory.rs
@@ -104,11 +104,24 @@ fn plugin_list_json_lists_machine_readable_packs() {
         "{stdout}"
     );
     assert!(
-        stdout.contains(r#""target_runtime": "asset_only_declarative_schema_tbd""#),
+        stdout.contains(r#""target_runtime": "declarative_asset_plus_native_reedline_actions""#),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains(r#""target_runtime": "declarative_asset_plus_native_theme_renderer""#),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains(r#""target_runtime": "host_builtin_and_process_provider""#),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains(r#""missing_host_api_or_decision": "wasm_provider_abi""#),
         "{stdout}"
     );
     assert!(stdout.contains(r#""shell_mutating": true"#), "{stdout}");
     assert!(stdout.contains(r#""fallback_needed": true"#), "{stdout}");
+    assert!(stdout.contains(r#""fallback_needed": false"#), "{stdout}");
     assert!(stdout.contains(r#""name": "thefuck""#), "{stdout}");
 }
 #[test]
@@ -279,6 +292,62 @@ fn plugin_themes_marks_external_bundle_trust_source() {
     let _ = fs::remove_dir_all(temp);
 }
 #[test]
+fn plugin_prompts_lists_builtin_and_bundle_presets() {
+    let temp = temp_dir("plugin-prompts-catalog");
+    let bundle = temp.join("bundle");
+    write_minimal_test_bundle(&bundle, "9.9.11", "Prompt catalog fixture.");
+    let envs = [("WINUXSH_PLUGIN_BUNDLE_PATH", bundle)];
+    let text = run_winuxsh_with_env(&["plugin", "prompts"], &envs);
+    assert_success(&text, "plugin prompts text");
+    let stdout = stdout_text(&text);
+    assert!(stdout.contains("Winuxsh prompt presets"), "{stdout}");
+    assert!(
+        stdout.contains("- classic source=builtin owner=winuxsh"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains(
+            "- classic source=bundle owner=oh-my-winuxsh@9.9.11 bundle=oh-my-winuxsh pack=git"
+        ),
+        "{stdout}"
+    );
+    assert!(stdout.contains("separator=\"|\""), "{stdout}");
+    let json = run_winuxsh_with_env(&["plugin", "prompts", "--json"], &envs);
+    assert_success(&json, "plugin prompts json");
+    let stdout = stdout_text(&json);
+    assert!(stdout.contains(r#""source": "bundle""#), "{stdout}");
+    assert!(
+        stdout.contains(r#""git_prompt_format": "bundle:{git_branch}""#),
+        "{stdout}"
+    );
+    let _ = fs::remove_dir_all(temp);
+}
+#[test]
+fn plugin_keybindings_lists_bundle_assets() {
+    let temp = temp_dir("plugin-keybindings-catalog");
+    let bundle = temp.join("bundle");
+    write_keybindings_test_bundle(&bundle, "9.9.6");
+    let envs = [("WINUXSH_PLUGIN_BUNDLE_PATH", bundle)];
+    let text = run_winuxsh_with_env(&["plugin", "keybindings"], &envs);
+    assert_success(&text, "plugin keybindings text");
+    let stdout = stdout_text(&text);
+    assert!(stdout.contains("Winuxsh keybindings"), "{stdout}");
+    assert!(
+        stdout.contains("- common keymap=all source=bundle owner=oh-my-winuxsh@9.9.6 bindings=2"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("Tab -> complete-word"), "{stdout}");
+    let json = run_winuxsh_with_env(&["plugin", "keybindings", "--json"], &envs);
+    assert_success(&json, "plugin keybindings json");
+    let stdout = stdout_text(&json);
+    assert!(stdout.contains(r#""keymap": "emacs""#), "{stdout}");
+    assert!(
+        stdout.contains(r#""action": "beginning-of-line""#),
+        "{stdout}"
+    );
+    let _ = fs::remove_dir_all(temp);
+}
+#[test]
 fn plugin_info_text_describes_one_pack() {
     let output = run_winuxsh(&["plugin", "info", "git"]);
     assert_success(&output, "plugin info text");
@@ -335,11 +404,11 @@ fn plugin_info_marks_command_not_found_provider_candidate() {
         "{stdout}"
     );
     assert!(
-        stdout.contains("Target runtime: process_provider_available_builtin_until_migration"),
+        stdout.contains("Target runtime: host_builtin_and_process_provider"),
         "{stdout}"
     );
     assert!(
-        stdout.contains("Missing host API/decision: bundle_migration_decision,wasm_provider_abi"),
+        stdout.contains("Missing host API/decision: wasm_provider_abi"),
         "{stdout}"
     );
     assert!(stdout.contains("Shell-mutating: no"), "{stdout}");
@@ -366,16 +435,18 @@ fn plugin_review_marks_command_not_found_process_provider_readiness() {
         "{stdout}"
     );
     assert!(
-        stdout.contains("Target runtime: process_provider_available_builtin_until_migration"),
+        stdout.contains("Target runtime: host_builtin_and_process_provider"),
         "{stdout}"
     );
     assert!(stdout.contains("Shell-mutating: no"), "{stdout}");
     assert!(
-        stdout.contains("process provider binding exists for command-not-found"),
+        stdout.contains(
+            "command-not-found is wired to the host call-site and process-provider bridge"
+        ),
         "{stdout}"
     );
     assert!(
-        stdout.contains("WASM providers still require a separate ABI"),
+        stdout.contains("WASM providers still need a separate ABI"),
         "{stdout}"
     );
 }


### PR DESCRIPTION
## Summary
- add plugin prompt/keybinding catalog CLI surfaces with JSON output
- wire bundle keybinding assets into native Reedline keybindings when the keybindings pack is enabled
- update readiness reporting so prompts/themes/keybindings are concrete host-consumed assets, not pending migration decisions
- clarify docs: static plugin assets do not need WASM; command-not-found only still lacks a WASM provider ABI

## Tests
- cargo fmt --check -p winuxsh -p winuxsh-runtime
- cargo test --test plugin_inventory --locked
- cargo test -p winuxsh-runtime --lib --locked
- cargo test --workspace --locked
