### PR TITLE
Prepare Winuxsh 0.9.4 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1538,7 +1538,7 @@ dependencies = [
 
 [[package]]
 name = "winuxsh"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "winuxsh-runtime"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winuxsh"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2021"
 rust-version = "1.70"
 license = "GPL-3.0-or-later"

--- a/crates/winuxsh-runtime/Cargo.toml
+++ b/crates/winuxsh-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winuxsh-runtime"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2021"
 rust-version = "1.70"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Summary
- bump winuxsh and winuxsh-runtime package versions to 0.9.4
- sync Cargo.lock so the v0.9.4 release workflow tag check can pass

## Tests
- cargo check
- cargo fmt --check -p winuxsh -p winuxsh-runtime
- cargo test --workspace --locked
