### PR TITLE
[codex] include common commands in partial completion

### DIFF
--- a/crates/winuxsh-runtime/src/completion/command.rs
+++ b/crates/winuxsh-runtime/src/completion/command.rs
@@ -14,9 +14,10 @@ static PATH_CMD_CACHE: Mutex<Option<(Vec<String>, Vec<String>)>> = Mutex::new(No
 pub struct CommandCompleter;
 
 impl CommandCompleter {
-    /// Get all available commands (built-in + PATH)
+    /// Get all available commands (built-in + common + PATH)
     pub fn get_all_commands() -> Vec<String> {
         let mut commands = Self::get_builtin_commands();
+        commands.extend(Self::get_common_commands());
         commands.extend(Self::get_path_commands_cached());
         commands.sort();
         commands.dedup();
@@ -336,6 +337,13 @@ mod tests {
         );
         let result = CommandCompleter::complete(&ctx).unwrap().unwrap();
         assert!(result.completions.contains(&"grep".to_string()));
+    }
+
+    #[test]
+    fn command_completion_includes_common_commands_for_partial_input() {
+        let ctx = CompletionContext::new(std::path::PathBuf::from("."), "oh-".to_string(), 3);
+        let result = CommandCompleter::complete(&ctx).unwrap().unwrap();
+        assert!(result.completions.contains(&"oh-my-winuxsh".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes partial command completion so repository-provided common commands are included alongside shell builtins and PATH executables.

Before this change, `CommandCompleter::complete` only considered builtins and PATH commands for non-empty command input. As a result, partial input such as `oh-` did not suggest `oh-my-winuxsh`, even though that command is listed in the common command catalog.

## Changes

- Adds `get_common_commands()` to `CommandCompleter::get_all_commands()`.
- Keeps the existing sort/dedup behavior so duplicates between builtins, common commands, and PATH entries collapse cleanly.
- Adds a regression test for partial input `oh-` returning `oh-my-winuxsh`.

## Validation

Run locally on Windows:

```text
cargo test -p winuxsh-runtime completion::command
cargo test --test completion_probe completion_probe_loads_startup_rc
rustfmt --check crates/winuxsh-runtime/src/completion/command.rs
git diff --check origin/master..HEAD
```

All commands passed.

## Notes for reviewers

The PR branch has been rebased onto current `master` (`f64e1e8`) to avoid stale-base noise. The final diff is intentionally limited to `crates/winuxsh-runtime/src/completion/command.rs`.

Fixes #54.
