### PR TITLE
[codex] Complete shell functions in command completion

### DIFF
--- a/crates/winuxsh-runtime/src/completion/completer.rs
+++ b/crates/winuxsh-runtime/src/completion/completer.rs
@@ -17,6 +17,7 @@ pub struct CompletionState {
     pub current_dir: PathBuf,
     pub env_vars: HashMap<String, String>,
     pub aliases: HashSet<String>,
+    pub functions: HashSet<String>,
     pub behavior: CompletionBehavior,
     /// Registered completion plugins (e.g. command completion, external tool completion)
     pub plugins: Vec<Arc<dyn CompletionPlugin>>,
@@ -28,6 +29,7 @@ impl CompletionState {
             current_dir,
             env_vars: HashMap::new(),
             aliases: HashSet::new(),
+            functions: HashSet::new(),
             behavior: CompletionBehavior::default(),
             plugins: Vec::new(),
         }
@@ -102,12 +104,13 @@ impl WinuxshCompleter {
 
     /// Complete input
     fn complete_input(&mut self, input: &str, cursor_pos: usize) -> Vec<Suggestion> {
-        let (current_dir, env_vars, aliases, behavior, plugins) =
+        let (current_dir, env_vars, aliases, functions, behavior, plugins) =
             if let Ok(state) = self.state.lock() {
                 (
                     state.current_dir.clone(),
                     state.env_vars.clone(),
                     state.aliases.clone(),
+                    state.functions.clone(),
                     state.behavior,
                     state.plugins.clone(),
                 )
@@ -126,6 +129,8 @@ impl WinuxshCompleter {
         // only showing PATH executables like `winver` or `winrm`.
         let cwd_dir_suggestions = self.cwd_directory_suggestions_at_command_position(&context);
         let alias_suggestions = self.alias_suggestions_at_command_position(&context, &aliases);
+        let function_suggestions =
+            self.function_suggestions_at_command_position(&context, &functions);
 
         // Try each plugin in order; only the first non-None result is used
         for plugin in &plugins {
@@ -141,10 +146,16 @@ impl WinuxshCompleter {
         if !cwd_dir_suggestions.is_empty() {
             let mut combined = cwd_dir_suggestions;
             combined.extend(alias_suggestions.clone());
+            combined.extend(function_suggestions.clone());
             combined.extend(all_suggestions);
             all_suggestions = combined;
         } else if !alias_suggestions.is_empty() {
             let mut combined = alias_suggestions;
+            combined.extend(function_suggestions.clone());
+            combined.extend(all_suggestions);
+            all_suggestions = combined;
+        } else if !function_suggestions.is_empty() {
+            let mut combined = function_suggestions;
             combined.extend(all_suggestions);
             all_suggestions = combined;
         }
@@ -271,6 +282,47 @@ impl WinuxshCompleter {
             .map(|candidate| Suggestion {
                 value: candidate,
                 description: Some("alias".to_string()),
+                style: None,
+                extra: None,
+                span: Span {
+                    start: span_start,
+                    end: span_end,
+                },
+                append_whitespace: true,
+            })
+            .collect()
+    }
+
+    fn function_suggestions_at_command_position(
+        &self,
+        context: &CompletionContext,
+        functions: &HashSet<String>,
+    ) -> Vec<Suggestion> {
+        if !context.is_command_position() {
+            return Vec::new();
+        }
+        let Some(word) = context.get_current_word() else {
+            return Vec::new();
+        };
+        if word.contains('/') || word.contains('\\') || word.starts_with('.') {
+            return Vec::new();
+        }
+
+        let (span_start, span_end) = context
+            .current_word_span()
+            .unwrap_or((context.cursor_pos, context.cursor_pos));
+        let mut candidates: Vec<_> = functions
+            .iter()
+            .filter(|function| context.behavior.matches(function, &word))
+            .cloned()
+            .collect();
+        candidates.sort();
+
+        candidates
+            .into_iter()
+            .map(|candidate| Suggestion {
+                value: candidate,
+                description: Some("function".to_string()),
                 style: None,
                 extra: None,
                 span: Span {

--- a/crates/winuxsh-runtime/src/shell.rs
+++ b/crates/winuxsh-runtime/src/shell.rs
@@ -1983,6 +1983,7 @@ impl Shell {
                 .unwrap_or_else(|| state.current_dir.clone());
             state.env_vars = self.executor.env_vars_snapshot();
             state.aliases = self.aliases.keys().cloned().collect();
+            state.functions = self.executor.functions_snapshot().into_iter().collect();
         }
     }
 

--- a/tests/completion_probe.rs
+++ b/tests/completion_probe.rs
@@ -171,6 +171,16 @@ fn completion_probe_loads_startup_rc_aliases() {
 }
 
 #[test]
+fn completion_probe_loads_startup_rc_functions() {
+    let env = ProbeEnv::new("winuxsh-completion-rc-function");
+    env.write_rc("fetch_repo() { git fetch; }\n");
+
+    let suggestions = run_probe("fetch_", &env, &[]);
+
+    assert_contains(&suggestions, "fetch_repo");
+}
+
+#[test]
 fn path_completion_escapes_spaces_in_candidates() {
     let env = ProbeEnv::new("winuxsh-completion-spaces");
     std::fs::create_dir_all(env.start.join("two dir")).unwrap();


### PR DESCRIPTION
## What changed

- Track shell function names in shared completion state alongside aliases.
- Surface matching function names at command position with a function description.
- Add a completion-probe regression test for functions defined by startup rc.

## Why

Functions defined in startup rc were available to the shell, but the REPL completion state only mirrored aliases. As a result, Tab completion could show aliases and PATH commands but not user-defined functions.

Fixes #53.

## Validation

- cargo fmt --check -p winuxsh
- cargo test --test completion_probe --locked, with WINUXCMD_PATH pointing at a local WinuxCmd install
- cargo test --workspace --locked -- --test-threads=1, with inherited WINUXSH prompt environment cleared and WinuxCmd on PATH
