### PR TITLE
Complete current-directory paths at command position

### DIFF
--- a/crates/winuxsh-runtime/src/completion/completer.rs
+++ b/crates/winuxsh-runtime/src/completion/completer.rs
@@ -122,12 +122,12 @@ impl WinuxshCompleter {
             CompletionContext::with_behavior(current_dir, input.to_string(), cursor_pos, behavior);
         let mut all_suggestions = Vec::new();
 
-        // At command position, also surface matching directories from the
-        // current working directory ahead of PATH command matches. This
-        // mirrors the Windows-shell expectation that `win` in a folder
-        // containing `winuxsh/` should offer `winuxsh/` first, instead of
-        // only showing PATH executables like `winver` or `winrm`.
-        let cwd_dir_suggestions = self.cwd_directory_suggestions_at_command_position(&context);
+        // At command position, also surface matching entries from the current
+        // working directory ahead of PATH command matches. This mirrors the
+        // Windows-shell expectation that `win` in a folder containing
+        // `./winuxsh/` should offer `./winuxsh/` first, instead of only showing
+        // PATH executables like `winver` or `winrm`.
+        let cwd_path_suggestions = self.cwd_path_suggestions_at_command_position(&context);
         let alias_suggestions = self.alias_suggestions_at_command_position(&context, &aliases);
         let function_suggestions =
             self.function_suggestions_at_command_position(&context, &functions);
@@ -141,10 +141,10 @@ impl WinuxshCompleter {
             }
         }
 
-        // Directories from cwd take priority over PATH commands so users can
-        // `cd winuxsh`/open `winuxsh/` without typing `./` first.
-        if !cwd_dir_suggestions.is_empty() {
-            let mut combined = cwd_dir_suggestions;
+        // Current-directory paths take priority over PATH commands so users can
+        // complete local files and directories without typing `./` first.
+        if !cwd_path_suggestions.is_empty() {
+            let mut combined = cwd_path_suggestions;
             combined.extend(alias_suggestions.clone());
             combined.extend(function_suggestions.clone());
             combined.extend(all_suggestions);
@@ -177,19 +177,17 @@ impl WinuxshCompleter {
         all_suggestions
     }
 
-    /// Build directory-only suggestions from the current working directory
-    /// when the cursor is at command position. Returns suggestions with the
-    /// same `span`/`append_whitespace` shape as the rest of the pipeline.
-    fn cwd_directory_suggestions_at_command_position(
+    /// Build current-directory path suggestions when the cursor is at command
+    /// position. Returns suggestions with the same `span` shape as the rest of
+    /// the pipeline.
+    fn cwd_path_suggestions_at_command_position(
         &self,
         context: &CompletionContext,
     ) -> Vec<Suggestion> {
         if !context.is_command_position() {
             return Vec::new();
         }
-        let Some(word) = context.get_current_word() else {
-            return Vec::new();
-        };
+        let word = context.get_current_word().unwrap_or_default();
         // Skip flag-like input and explicit path indicators; those are handled
         // by the path completer with its own prefix preservation rules.
         if word.starts_with('-')
@@ -199,30 +197,29 @@ impl WinuxshCompleter {
         {
             return Vec::new();
         }
-        if word.is_empty() {
-            return Vec::new();
-        }
 
         let entries = match std::fs::read_dir(&context.current_dir) {
             Ok(entries) => entries,
             Err(_) => return Vec::new(),
         };
 
-        let mut candidates: Vec<String> = Vec::new();
+        let mut candidates: Vec<CwdPathCandidate> = Vec::new();
         for entry in entries.flatten() {
             let file_name = entry.file_name().to_string_lossy().to_string();
             if !context.behavior.matches(&file_name, &word) {
                 continue;
             }
             let is_dir = entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false);
-            if !is_dir {
-                continue;
-            }
             if file_name.starts_with('.') && !word.starts_with('.') {
                 continue;
             }
             let escaped = shell_escape_path_segment(&file_name);
-            candidates.push(format!("{escaped}/"));
+            let value = if is_dir {
+                format!("./{escaped}/")
+            } else {
+                format!("./{escaped}")
+            };
+            candidates.push(CwdPathCandidate { is_dir, value });
         }
 
         if candidates.is_empty() {
@@ -239,7 +236,8 @@ impl WinuxshCompleter {
         candidates
             .into_iter()
             .map(|candidate| Suggestion {
-                value: candidate,
+                append_whitespace: !candidate.is_dir,
+                value: candidate.value,
                 description: None,
                 style: None,
                 extra: None,
@@ -247,7 +245,6 @@ impl WinuxshCompleter {
                     start: span_start,
                     end: span_end,
                 },
-                append_whitespace: false,
             })
             .collect()
     }
@@ -373,6 +370,32 @@ fn should_append_completion_whitespace(completion: &str) -> bool {
     !(value.ends_with('/') || value.ends_with('\\'))
 }
 
+#[derive(Debug, Eq, PartialEq)]
+struct CwdPathCandidate {
+    is_dir: bool,
+    value: String,
+}
+
+impl Ord for CwdPathCandidate {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        match (self.is_dir, other.is_dir) {
+            (true, false) => std::cmp::Ordering::Less,
+            (false, true) => std::cmp::Ordering::Greater,
+            _ => self
+                .value
+                .to_ascii_lowercase()
+                .cmp(&other.value.to_ascii_lowercase())
+                .then_with(|| self.value.cmp(&other.value)),
+        }
+    }
+}
+
+impl PartialOrd for CwdPathCandidate {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 impl Completer for WinuxshCompleter {
     fn complete(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
         self.complete_input(line, pos)
@@ -452,8 +475,8 @@ mod cwd_priority_tests {
 
         let dir_suggestion = suggestions
             .iter()
-            .find(|suggestion| suggestion.value == "winuxsh/")
-            .unwrap_or_else(|| panic!("expected winuxsh/ ahead of PATH, got {suggestions:?}"));
+            .find(|suggestion| suggestion.value == "./winuxsh/")
+            .unwrap_or_else(|| panic!("expected ./winuxsh/ ahead of PATH, got {suggestions:?}"));
         assert_eq!(dir_suggestion.span.start, 0);
         assert_eq!(dir_suggestion.span.end, 3);
         assert!(!dir_suggestion.append_whitespace);
@@ -462,15 +485,15 @@ mod cwd_priority_tests {
         assert!(
             !suggestions
                 .iter()
-                .any(|suggestion| suggestion.value == "other/"),
-            "unexpected other/ in {suggestions:?}"
+                .any(|suggestion| suggestion.value == "./other/"),
+            "unexpected ./other/ in {suggestions:?}"
         );
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }
 
     #[test]
-    fn command_position_does_not_offer_cwd_files_only_directories() {
+    fn command_position_offers_matching_cwd_file_with_dot_slash() {
         let temp_dir = unique_temp_dir("winuxsh-cwd-priority-files");
         std::fs::create_dir_all(&temp_dir).unwrap();
         std::fs::write(temp_dir.join("winuxfile.txt"), "x").unwrap();
@@ -479,16 +502,44 @@ mod cwd_priority_tests {
         let mut completer = WinuxshCompleter::new(state);
         let suggestions = completer.complete("win", 3);
 
-        // A plain file at command position should never be offered as a
-        // command-position directory candidate. We only collect directories
-        // via the cwd shortcut, so file names must not appear even when they
-        // share the typed prefix. PATH commands may still show up via the
-        // command plugin, but no `winuxfile.txt` style entry.
+        let file_suggestion = suggestions
+            .iter()
+            .find(|suggestion| suggestion.value == "./winuxfile.txt")
+            .unwrap_or_else(|| panic!("expected cwd file with ./, got {suggestions:?}"));
+        assert_eq!(file_suggestion.span.start, 0);
+        assert_eq!(file_suggestion.span.end, 3);
+        assert!(file_suggestion.append_whitespace);
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn command_position_empty_input_offers_cwd_entries() {
+        let temp_dir = unique_temp_dir("winuxsh-cwd-priority-empty");
+        std::fs::create_dir_all(temp_dir.join("localdir")).unwrap();
+        std::fs::write(temp_dir.join("localfile.txt"), "x").unwrap();
+        std::fs::write(temp_dir.join(".hidden"), "x").unwrap();
+
+        let state = Arc::new(Mutex::new(CompletionState::new(temp_dir.clone())));
+        let mut completer = WinuxshCompleter::new(state);
+        let suggestions = completer.complete("", 0);
+
+        let dir_suggestion = suggestions
+            .iter()
+            .find(|suggestion| suggestion.value == "./localdir/")
+            .unwrap_or_else(|| panic!("expected cwd dir on empty Tab, got {suggestions:?}"));
+        assert!(!dir_suggestion.append_whitespace);
+
+        let file_suggestion = suggestions
+            .iter()
+            .find(|suggestion| suggestion.value == "./localfile.txt")
+            .unwrap_or_else(|| panic!("expected cwd file on empty Tab, got {suggestions:?}"));
+        assert!(file_suggestion.append_whitespace);
         assert!(
             !suggestions
                 .iter()
-                .any(|suggestion| suggestion.value.contains("winuxfile")),
-            "file leaked into cwd directory suggestions: {suggestions:?}"
+                .any(|suggestion| suggestion.value == ".hidden"),
+            "hidden file leaked without dot prefix: {suggestions:?}"
         );
 
         let _ = std::fs::remove_dir_all(temp_dir);


### PR DESCRIPTION
## Summary

- suggest matching current-directory files and directories at command position without requiring users to type ./ first
- display command-position cwd suggestions as ./file or ./dir/ for shell-correct invocation
- keep explicit path completion behavior for ./ and dot-prefixed hidden paths

## Validation

- cargo fmt --check -p winuxsh
- cargo test -p winuxsh-runtime completer::cwd_priority_tests --locked
- cargo build --locked
- cargo test --workspace --locked