### PR TITLE
fix(winuxcmd): keep grep/sed/awk/find pattern operands off the slash-drive rewrite

### DIFF
--- a/crates/winuxsh-runtime/src/shell.rs
+++ b/crates/winuxsh-runtime/src/shell.rs
@@ -2870,7 +2870,10 @@ fn mask_first_positional_pattern(
                 i += 2;
                 continue;
             }
-            if let Some(name) = arg.strip_prefix("--").and_then(|rest| rest.split('=').next()) {
+            if let Some(name) = arg
+                .strip_prefix("--")
+                .and_then(|rest| rest.split('=').next())
+            {
                 let long = format!("--{name}");
                 if pattern_opts.contains(&long.as_str()) || file_opts.contains(&long.as_str()) {
                     pattern_via_option = true;

--- a/crates/winuxsh-runtime/src/shell.rs
+++ b/crates/winuxsh-runtime/src/shell.rs
@@ -2635,14 +2635,18 @@ fn normalize_winuxcmd_slash_drive_command(command: &mut rubash::parser::CommandN
         }
     }
 
-    let Some(command_name) = command.words.first() else {
+    let Some(command_name) = command.words.first().cloned() else {
         return;
     };
-    if !is_winuxcmd_path_command(command_name) {
+    if !is_winuxcmd_path_command(&command_name) {
         return;
     }
 
-    for word in command.words.iter_mut().skip(1) {
+    let translate = winuxcmd_path_translation_mask(&command_name, &command.words);
+    for (index, word) in command.words.iter_mut().enumerate() {
+        if index == 0 || !translate.get(index).copied().unwrap_or(true) {
+            continue;
+        }
         if let Some(normalized) = slash_drive_arg_to_windows_native(word) {
             *word = normalized;
         }
@@ -2757,6 +2761,170 @@ const WINUXCMD_PATH_COMMANDS: &[&str] = &[
     "wc",
     "xxd",
 ];
+
+/// Per-argument mask controlling which WinuxCmd command arguments may be
+/// slash-drive translated. Pattern, regex, or script operands of `grep`,
+/// `sed`, `awk`, and `find` are left untouched so a `/x/`-shaped pattern is
+/// not rewritten into a Windows drive path (unixwin/winuxsh#61).
+fn winuxcmd_path_translation_mask(command_name: &str, words: &[String]) -> Vec<bool> {
+    let mut mask = vec![true; words.len()];
+    if let Some(first) = mask.first_mut() {
+        *first = false;
+    }
+
+    let name = command_name.trim_end_matches(".exe").to_ascii_lowercase();
+    match name.as_str() {
+        "grep" => mask_first_positional_pattern(
+            words,
+            &mut mask,
+            &["-e", "--regexp"],
+            &["-f", "--file"],
+            &[
+                "-m",
+                "--max-count",
+                "-A",
+                "--after-context",
+                "-B",
+                "--before-context",
+                "-C",
+                "--context",
+                "-d",
+                "--devices",
+                "-D",
+                "--directories",
+            ],
+        ),
+        "sed" => mask_first_positional_pattern(
+            words,
+            &mut mask,
+            &["-e", "--expression"],
+            &["-f", "--file"],
+            &[],
+        ),
+        "awk" => mask_first_positional_pattern(words, &mut mask, &[], &["-f", "--file"], &[]),
+        "find" => mask_find_expression(words, &mut mask),
+        _ => {}
+    }
+    mask
+}
+
+fn short_option_char(opts: &[&str]) -> Option<char> {
+    opts.iter().find_map(|opt| {
+        let bytes = opt.as_bytes();
+        if bytes.len() == 2 && bytes[0] == b'-' && bytes[1].is_ascii_alphabetic() {
+            Some(bytes[1] as char)
+        } else {
+            None
+        }
+    })
+}
+
+/// Marks the first positional operand of a pattern/script command as
+/// non-translatable. `pattern_opts` consume a separate pattern value,
+/// `file_opts` consume a separate file operand, and `value_opts` consume a
+/// numeric or action value; any of the first two suppresses the positional
+/// pattern. Attached `--opt=value` and `-oVALUE` clusters carry the value in
+/// the same token and only gate the positional operand.
+fn mask_first_positional_pattern(
+    words: &[String],
+    mask: &mut [bool],
+    pattern_opts: &[&str],
+    file_opts: &[&str],
+    value_opts: &[&str],
+) {
+    let pattern_short = short_option_char(pattern_opts);
+    let file_short = short_option_char(file_opts);
+
+    let mut pattern_via_option = false;
+    let mut after_dashdash = false;
+    let mut first_positional: Option<usize> = None;
+    let mut i = 1;
+    while i < words.len() {
+        let arg = words[i].as_str();
+        if !after_dashdash && arg == "--" {
+            after_dashdash = true;
+            i += 1;
+            continue;
+        }
+        let is_option = !after_dashdash && arg.starts_with('-') && arg.len() > 1;
+
+        if is_option {
+            if pattern_opts.contains(&arg) {
+                pattern_via_option = true;
+                if let Some(slot) = mask.get_mut(i + 1) {
+                    *slot = false;
+                }
+                i += 2;
+                continue;
+            }
+            if file_opts.contains(&arg) {
+                pattern_via_option = true;
+                i += 2;
+                continue;
+            }
+            if value_opts.contains(&arg) {
+                i += 2;
+                continue;
+            }
+            if let Some(name) = arg.strip_prefix("--").and_then(|rest| rest.split('=').next()) {
+                let long = format!("--{name}");
+                if pattern_opts.contains(&long.as_str()) || file_opts.contains(&long.as_str()) {
+                    pattern_via_option = true;
+                }
+            } else if let Some(cluster) = arg.strip_prefix('-') {
+                if let Some(first) = cluster.chars().next() {
+                    if Some(first) == pattern_short || Some(first) == file_short {
+                        pattern_via_option = true;
+                    }
+                }
+            }
+        } else if first_positional.is_none() {
+            first_positional = Some(i);
+        }
+        i += 1;
+    }
+
+    if !pattern_via_option {
+        if let Some(idx) = first_positional {
+            if let Some(slot) = mask.get_mut(idx) {
+                *slot = false;
+            }
+        }
+    }
+}
+
+/// Marks `find` pattern-primary values (`-name`, `-path`, `-regex`, ...) as
+/// non-translatable. Leading non-option operands are starting paths and stay
+/// translatable.
+fn mask_find_expression(words: &[String], mask: &mut [bool]) {
+    let pattern_primaries = [
+        "-name",
+        "-path",
+        "-regex",
+        "-iregex",
+        "-ipath",
+        "-lname",
+        "-wholename",
+        "-ilname",
+        "-iwholename",
+    ];
+    let mut in_expression = false;
+    let mut i = 1;
+    while i < words.len() {
+        let arg = words[i].as_str();
+        if !in_expression && (arg.starts_with('-') || matches!(arg, "!" | "(" | ")")) {
+            in_expression = true;
+        }
+        if in_expression && pattern_primaries.contains(&arg) {
+            if let Some(slot) = mask.get_mut(i + 1) {
+                *slot = false;
+            }
+            i += 2;
+            continue;
+        }
+        i += 1;
+    }
+}
 
 fn slash_drive_arg_to_windows_native(value: &str) -> Option<String> {
     if let Some(path) = slash_drive_path_to_windows_native(value) {
@@ -4961,6 +5129,47 @@ winuxsh_run_chpwd_hooks() {
                 and_or_list.commands[1].words[1],
                 "/c/Users/tmp/test.XXXXXX.tmp"
             );
+        }
+    }
+
+    #[test]
+    fn winuxcmd_pattern_operands_are_not_slash_drive_translated() {
+        let tokens = tokenize(
+            "grep -F \"/h/\" /c/Users/file; grep /h/ /c/Users/file; grep -e /h/ /c/Users/file; grep -f /c/patfile /c/Users/file; grep -A 2 /h/ /c/Users/file; sed /h/d /c/Users/file; awk /h/ /c/Users/file; find /c/Users -name /h/ -print; find /e/ -maxdepth 1",
+        );
+        let mut ast = parse(&tokens);
+        normalize_winuxcmd_slash_drive_args(&mut ast);
+
+        if cfg!(windows) {
+            assert_eq!(ast.commands[0].words[2], "/h/");
+            assert_eq!(ast.commands[0].words[3], "C:/Users/file");
+            assert_eq!(ast.commands[1].words[1], "/h/");
+            assert_eq!(ast.commands[1].words[2], "C:/Users/file");
+            assert_eq!(ast.commands[2].words[2], "/h/");
+            assert_eq!(ast.commands[2].words[3], "C:/Users/file");
+            assert_eq!(ast.commands[3].words[2], "C:/patfile");
+            assert_eq!(ast.commands[3].words[3], "C:/Users/file");
+            assert_eq!(ast.commands[4].words[1], "-A");
+            assert_eq!(ast.commands[4].words[2], "2");
+            assert_eq!(ast.commands[4].words[3], "/h/");
+            assert_eq!(ast.commands[4].words[4], "C:/Users/file");
+            assert_eq!(ast.commands[5].words[1], "/h/d");
+            assert_eq!(ast.commands[5].words[2], "C:/Users/file");
+            assert_eq!(ast.commands[6].words[1], "/h/");
+            assert_eq!(ast.commands[6].words[2], "C:/Users/file");
+            assert_eq!(ast.commands[7].words[1], "C:/Users");
+            assert_eq!(ast.commands[7].words[3], "/h/");
+            assert_eq!(ast.commands[8].words[1], "E:/");
+        } else {
+            assert_eq!(ast.commands[0].words[2], "/h/");
+            assert_eq!(ast.commands[0].words[3], "/c/Users/file");
+            assert_eq!(ast.commands[3].words[2], "/c/patfile");
+            assert_eq!(ast.commands[4].words[3], "/h/");
+            assert_eq!(ast.commands[5].words[1], "/h/d");
+            assert_eq!(ast.commands[6].words[1], "/h/");
+            assert_eq!(ast.commands[7].words[1], "/c/Users");
+            assert_eq!(ast.commands[7].words[3], "/h/");
+            assert_eq!(ast.commands[8].words[1], "/e/");
         }
     }
 

--- a/crates/winuxsh-runtime/src/winuxcmd.rs
+++ b/crates/winuxsh-runtime/src/winuxcmd.rs
@@ -318,8 +318,7 @@ fn is_winuxcmd_installation_entry(entry: &str) -> bool {
     #[cfg(windows)]
     {
         let path = PathBuf::from(entry.trim_matches('"'));
-        return path.join("winuxcmd.exe").is_file()
-            || path.join("usr/bin/winuxcmd.exe").is_file();
+        return path.join("winuxcmd.exe").is_file() || path.join("usr/bin/winuxcmd.exe").is_file();
     }
 
     #[cfg(not(windows))]
@@ -535,10 +534,7 @@ mod tests {
 
         assert_eq!(candidates[0], exe_dir.join("usr/bin/winuxcmd.exe"));
         assert_eq!(candidates[1], exe_dir.join("winuxcmd.exe"));
-        assert_eq!(
-            candidates[2],
-            exe_dir.join("winuxcmd/usr/bin/winuxcmd.exe")
-        );
+        assert_eq!(candidates[2], exe_dir.join("winuxcmd/usr/bin/winuxcmd.exe"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,10 @@ fn run(args: &[String]) -> anyhow::Result<()> {
 
     let first = &args[1];
     if first.starts_with('-')
-        && !matches!(first.as_str(), "-h" | "--help" | "-V" | "--version" | "-C" | "--repl-command")
+        && !matches!(
+            first.as_str(),
+            "-h" | "--help" | "-V" | "--version" | "-C" | "--repl-command"
+        )
         && ShellInvocation::parse(&args[1..]).is_ok()
     {
         return run_shell_invocation(&args[1..]);
@@ -153,8 +156,8 @@ fn run(args: &[String]) -> anyhow::Result<()> {
 }
 
 fn run_shell_invocation(args: &[String]) -> anyhow::Result<()> {
-    let invocation = ShellInvocation::parse(args)
-        .map_err(|error| anyhow::anyhow!("winuxsh: {}", error))?;
+    let invocation =
+        ShellInvocation::parse(args).map_err(|error| anyhow::anyhow!("winuxsh: {}", error))?;
     let mut shell = if invocation.read_stdin {
         winuxsh_runtime::Shell::new_for_stdin_script()?
     } else {

--- a/tests/issue59_wildcards.rs
+++ b/tests/issue59_wildcards.rs
@@ -9,7 +9,11 @@ fn winuxsh_binary() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("target")
         .join("debug")
-        .join(if cfg!(windows) { "winuxsh.exe" } else { "winuxsh" })
+        .join(if cfg!(windows) {
+            "winuxsh.exe"
+        } else {
+            "winuxsh"
+        })
 }
 
 #[test]


### PR DESCRIPTION
Part of #61. The AST slash-drive normalizer rewrote every `/X/`-shaped argument of WinuxCmd path commands into a Windows drive path, so a pattern operand such as `grep -F "/h/"` arrived at the program as `H:\` and never matched.

Add a per-argument translation mask for the pattern/script commands:

- `grep`: first positional operand is the pattern (skipped); `-e/--regexp` values skipped; `-f/--file` values still translated; value-taking context options (`-A/-B/-C/-m/-d/-D`) consume their argument so the pattern position is not mis-detected.
- `sed`: first positional operand is the script; `-e/--expression` skipped, `-f/--file` translated.
- `awk`: first positional operand is the program unless `-f/--file` supplies it.
- `find`: leading operands stay translated (start paths); `-name/-path/-regex/-iregex/-ipath/-lname/-wholename/-ilname/-iwholename` values skipped.

File operands and `ls /d/` style usage are unchanged. Drive-root and unquoted pathspec edge cases remain deferred under #62 and are intentionally not addressed here.

Verification: `cargo fmt --check` clean on the touched file; `cargo test -p winuxsh-runtime --lib` 202 passed (new `winuxcmd_pattern_operands_are_not_slash_drive_translated` covers grep/sed/awk/find cases on Windows and non-Windows); existing `winuxcmd_slash_drive_args_are_translated_for_path_commands` still green.